### PR TITLE
refs #40 SEO対応: robots.txt / sitemap.xml / OGP タグの追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Dev server (Japanese locale, port 6200)
+yarn start
+
+# Full production build (both ja + en locales) + postbuild script
+yarn build
+
+# Build single locale
+ng build --configuration=ja
+ng build --configuration=en
+
+# Run unit tests
+yarn test
+
+# Build + serve SSG output locally
+./ssg-local.sh
+
+# Extract i18n messages (run after adding new $localize strings)
+yarn ng extract-i18n
+
+# Verify no untranslated messages remain
+grep -n '<target/>' src/resources/texts/def/messages.en.xlf
+```
+
+**Package manager: Yarn only. Never use npm.**
+
+## Architecture Overview
+
+Angular 21 SSG (Static Site Generation) app hosted on S3. Two locales: **ja** (source) and **en**.
+
+### Build pipeline
+
+1. `ng build` — Angular outputs `dist/ng-devtools/browser/ja/` and `dist/ng-devtools/browser/en/`
+2. `scripts/postbuild.mjs` runs automatically and:
+   - Copies `404.html` to browser root and removes it from locale dirs
+   - Copies favicons to browser root
+   - Injects Google AdSense `<script>` into every `index.html`
+   - Injects `canonical` + `hreflang` `<link>` tags into every `index.html`
+
+When adding new postbuild logic, extend `scripts/postbuild.mjs`.
+
+### i18n
+
+- Source locale is **ja** — write all template text in Japanese
+- English translations live in `src/resources/texts/def/messages.en.xlf`
+- Use `$localize` with explicit custom IDs: `` $localize`:@@page.example.title:例のタイトル` ``
+- After adding strings: run `yarn ng extract-i18n`, then add `<target>` tags in the `.xlf` file
+
+### Key directories
+
+- `src/app/pages/` — one folder per tool/page (route + component + help component)
+- `src/app/components/` — shared UI components
+- `src/app/core/services/` — platform-safe services (e.g. `PlatformService`)
+- `src/app/services/` — app-level services (help drawer, cookie consent, etc.)
+- `src/resources/menu/def/menu-def.ts` — single source of truth for all menu items and descriptions
+- `public/` — static assets copied as-is to every locale output dir
+
+### Angular conventions (strictly enforced)
+
+- **Standalone components only** — no NgModules
+- **`inject()`** for DI — never constructor injection
+- **Signals** for state: `signal()`, `computed()`, `effect()`, `input()`, `output()`, `model()`, `linkedSignal()`
+- **Built-in control flow** in templates: `@if`, `@for`, `@switch`, `@defer` — never `*ngIf`/`*ngFor`
+- **SCSS + Angular Material M3**: use CSS variables `--mat-sys-...` — never hardcoded colors
+- `PlatformService` must wrap all `window`/`localStorage` access (SSG runs in Node.js)
+
+### Adding a new tool page (mandatory checklist)
+
+1. Create page component + routes under `src/app/pages/tool-name-page/`
+2. Create help component at `src/app/pages/tool-name-page/tool-name-help/` (HTML-only, ≥500 ja chars, 4 sections: 概要・使い方・仕様/用語解説・ユースケース)
+3. Wire help component into the tool page via `HelpDrawerService` and `<ng-template #helpContent>`
+4. Add a `<section>` in `guide-page.component.html` that includes the help component
+5. Add a `<li>` entry in `src/app/components/sitemap/sitemap.component.html`
+6. Register the route in `src/app/app.routes.ts`
+7. Add menu item to `src/resources/menu/def/menu-def.ts`
+8. Run `yarn ng extract-i18n` and add English translations to `messages.en.xlf`
+
+### Commit message format
+
+```
+refs #{issue-number} {description}
+```
+
+Use the active issue number from context. Never guess from the branch name alone.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+Disallow: /ja/error/
+Disallow: /en/error/
+
+Sitemap: https://devtools.morihara.tech/sitemap.xml

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -15,6 +15,8 @@
  *     The client ID is read from environment.ts so it stays the single source
  *     of truth.
  *  5. Injects canonical and hreflang <link> tags into every locale's index.html.
+ *  6. Injects OGP <meta property="og:..."> tags into every locale's index.html.
+ *  7. Generates sitemap.xml at the browser root listing all indexable URLs.
  */
 
 import { copyFileSync, existsSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from 'fs';
@@ -72,6 +74,15 @@ for (const file of FAVICON_FILES) {
 
   copyFileSync(src, join(BROWSER_DIR, file));
   console.log(`Copied ${file} → ${BROWSER_DIR}/`);
+}
+
+// 2b. Copy robots.txt to root (must be served from the domain root, not under a locale prefix)
+const robotsSrc = findFileInLocales('robots.txt', LOCALES, BROWSER_DIR);
+if (robotsSrc) {
+  copyFileSync(robotsSrc, join(BROWSER_DIR, 'robots.txt'));
+  console.log(`Copied robots.txt → ${BROWSER_DIR}/`);
+} else {
+  console.warn('robots.txt not found in any locale directory — skipping.');
 }
 
 // 3. Inject AdSense <script> into every index.html under every locale dir.
@@ -156,3 +167,84 @@ for (const locale of LOCALES) {
     console.log(`Injected canonical/hreflang into ${indexPath}`);
   }
 }
+
+// 6. Inject OGP <meta property="og:..."> tags into every locale's index.html.
+//    Runs after step 5 so that canonical URL is already present in the HTML.
+
+/** Extracts the text content of the first matching HTML tag. */
+function extractTagContent(html, tagPattern) {
+  const match = html.match(tagPattern);
+  return match ? match[1] : null;
+}
+
+for (const locale of LOCALES) {
+  const localeDir = join(BROWSER_DIR, locale);
+  if (!existsSync(localeDir)) continue;
+
+  const allFiles = readdirSync(localeDir, { recursive: true, withFileTypes: false });
+  const indexFiles = /** @type {string[]} */ (allFiles)
+    .filter((f) => f === 'index.html' || f.endsWith('/index.html') || f.endsWith('\\index.html'))
+    .map((f) => join(localeDir, f));
+
+  for (const indexPath of indexFiles) {
+    if (indexPath.replace(/\\/g, '/').includes('/error/')) continue;
+
+    const html = readFileSync(indexPath, 'utf-8');
+    if (html.includes('property="og:title"')) {
+      console.log(`OGP already present in ${indexPath} — skipping.`);
+      continue;
+    }
+
+    const title = extractTagContent(html, /<title>([^<]+)<\/title>/);
+    const description = extractTagContent(html, /<meta name="description" content="([^"]+)"/);
+    const canonicalUrl = extractTagContent(html, /<link rel="canonical" href="([^"]+)"/);
+
+    if (!title || !canonicalUrl) {
+      console.warn(`Missing title or canonical in ${indexPath} — skipping OGP injection.`);
+      continue;
+    }
+
+    const ogTags = [
+      `  <meta property="og:type" content="website">`,
+      `  <meta property="og:site_name" content="devTools">`,
+      `  <meta property="og:title" content="${title}">`,
+      `  <meta property="og:url" content="${canonicalUrl}">`,
+      ...(description ? [`  <meta property="og:description" content="${description}">`] : []),
+    ].join('\n');
+
+    const injected = html.replace('</head>', `${ogTags}\n</head>`);
+    writeFileSync(indexPath, injected, 'utf-8');
+    console.log(`Injected OGP into ${indexPath}`);
+  }
+}
+
+// 7. Generate sitemap.xml at the browser root listing all indexable URLs.
+
+const lastmod = new Date().toISOString().slice(0, 10);
+const sitemapUrls = [];
+
+for (const locale of LOCALES) {
+  const localeDir = join(BROWSER_DIR, locale);
+  if (!existsSync(localeDir)) continue;
+
+  const allFiles = readdirSync(localeDir, { recursive: true, withFileTypes: false });
+  const indexFiles = /** @type {string[]} */ (allFiles)
+    .filter((f) => f === 'index.html' || f.endsWith('/index.html') || f.endsWith('\\index.html'))
+    .map((f) => join(localeDir, f));
+
+  for (const indexPath of indexFiles) {
+    if (indexPath.replace(/\\/g, '/').includes('/error/')) continue;
+
+    const relativePath = indexPath.slice(BROWSER_DIR.length + 1).replace(/\\/g, '/');
+    const urlPath = '/' + relativePath.replace(/index\.html$/, '');
+    sitemapUrls.push(`${BASE_URL}${urlPath}`);
+  }
+}
+
+const urlEntries = sitemapUrls
+  .map((loc) => `  <url>\n    <loc>${loc}</loc>\n    <lastmod>${lastmod}</lastmod>\n  </url>`)
+  .join('\n');
+
+const sitemapXml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urlEntries}\n</urlset>\n`;
+writeFileSync(join(BROWSER_DIR, 'sitemap.xml'), sitemapXml, 'utf-8');
+console.log(`Generated sitemap.xml with ${sitemapUrls.length} URLs → ${BROWSER_DIR}/sitemap.xml`);


### PR DESCRIPTION
## Summary

- `public/robots.txt` を新規作成（全ページ許可・エラーページ除外・Sitemap URL 宣言）
- `scripts/postbuild.mjs` にビルド後処理を追加:
  - **robots.txt** をブラウザルートへコピー（Angular は locale 配下にしか配置しないため）
  - **OGP タグ** を全 index.html に注入（`og:type` / `og:site_name` / `og:title` / `og:url` / `og:description`）
  - **sitemap.xml** を自動生成（ja+en 各16ページ、計32URL・エラーページ除外・lastmod 付き）
- `CLAUDE.md` を追加（ビルドコマンド・アーキテクチャ・新規ツール追加チェックリスト）

なお、このブランチは `fix/hreflang-canonical`（refs #152: canonical/hreflang 注入）をベースにしています。

## Test plan

- [ ] `yarn build` が正常終了すること
- [ ] `dist/ng-devtools/browser/robots.txt` が存在し、Sitemap ディレクティブが含まれること
- [ ] `dist/ng-devtools/browser/sitemap.xml` が生成され、32件の URL が含まれること（`/error/` 配下が除外されていること）
- [ ] `dist/ng-devtools/browser/ja/json-formatter/index.html` に `og:title` / `og:url` / `og:description` が含まれること
- [ ] デプロイ後、Google Search Console / Bing Webmaster Tools に sitemap.xml を登録すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)