### PR TITLE
refs #159 内部リンク(routerLink)とcanonical/sitemapの末尾スラッシュ不一致を解消

### DIFF
--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -128,6 +128,15 @@ if (!clientIdMatch) {
 
 const BASE_URL = 'https://devtools.morihara.tech';
 
+/**
+ * Removes a single trailing slash from a path, except for the root path "/"
+ * which is left untouched (BASE_URL + "/" is the canonical home URL).
+ */
+function stripTrailingSlash(urlPath) {
+  if (urlPath === '/') return urlPath;
+  return urlPath.endsWith('/') ? urlPath.slice(0, -1) : urlPath;
+}
+
 for (const locale of LOCALES) {
   const localeDir = join(BROWSER_DIR, locale);
   if (!existsSync(localeDir)) continue;
@@ -148,18 +157,21 @@ for (const locale of LOCALES) {
     }
 
     // Derive the URL path from the file path.
-    // e.g. dist/ng-devtools/browser/ja/json-formatter/index.html → /ja/json-formatter/
+    // e.g. dist/ng-devtools/browser/ja/json-formatter/index.html → /ja/json-formatter
+    // Trailing slashes are intentionally omitted to match the in-app routerLink
+    // format (e.g. routerLink="/json-formatter"), so that canonical/sitemap URLs
+    // line up with the URLs Googlebot discovers by following internal links.
     const relativePath = indexPath.slice(BROWSER_DIR.length + 1).replace(/\\/g, '/');
-    const urlPath = '/' + relativePath.replace(/index\.html$/, '');
+    const urlPath = stripTrailingSlash('/' + relativePath.replace(/index\.html$/, ''));
 
     const altLocale = locale === 'ja' ? 'en' : 'ja';
-    const altUrlPath = urlPath.replace(`/${locale}/`, `/${altLocale}/`);
+    const altUrlPath = urlPath.replace(`/${locale}`, `/${altLocale}`);
 
     const tags = [
       `  <link rel="canonical" href="${BASE_URL}${urlPath}">`,
       `  <link rel="alternate" hreflang="${locale}" href="${BASE_URL}${urlPath}">`,
       `  <link rel="alternate" hreflang="${altLocale}" href="${BASE_URL}${altUrlPath}">`,
-      `  <link rel="alternate" hreflang="x-default" href="${BASE_URL}/ja/">`,
+      `  <link rel="alternate" hreflang="x-default" href="${BASE_URL}/ja">`,
     ].join('\n');
 
     const injected = html.replace('</head>', `${tags}\n</head>`);
@@ -236,7 +248,7 @@ for (const locale of LOCALES) {
     if (indexPath.replace(/\\/g, '/').includes('/error/')) continue;
 
     const relativePath = indexPath.slice(BROWSER_DIR.length + 1).replace(/\\/g, '/');
-    const urlPath = '/' + relativePath.replace(/index\.html$/, '');
+    const urlPath = stripTrailingSlash('/' + relativePath.replace(/index\.html$/, ''));
     sitemapUrls.push(`${BASE_URL}${urlPath}`);
   }
 }


### PR DESCRIPTION
## Summary
- Issue #159: Search Consoleで「クロール済み - インデックス未登録」が複数件発生していた原因の修正。`routerLink`（末尾スラッシュなし）と postbuild.mjs が生成する canonical/hreflang/sitemap.xml（末尾スラッシュあり）のURL形式が不一致だったため、GooglebotがクロールしたスラッシュなしURLとcanonicalが指すスラッシュありURLが別ページとして扱われ、重複ページ判定によりインデックス未登録になっていた。
- `routerLink` 側は40箇所以上あり全て末尾スラッシュなしで記述されている。`app.routes.ts` のルート定義（`path: 'uuid-generator'` 等）も末尾スラッシュなしが自然。一方 postbuild.mjs のURL生成は1ヶ所（canonical/hreflang生成・sitemap生成）にロジックが集約されているため、こちらをスラッシュなしに統一する方が変更点が少なく安全と判断した。
- 統一前に本番サイトで `/ja/uuid-generator` と `/ja/uuid-generator/` の両方が CloudFront 経由で 200 を返すことを確認済み。リダイレクト設定変更は不要。
- canonical/hreflang/og:url/sitemap.xml の生成URLから末尾スラッシュを除去（トップページのみ `/ja` `/en` のように元々ルートディレクトリ相当だが、同様にスラッシュなしへ統一）。

## Test plan
- [x] `yarn build` を実行し、生成された `dist/ng-devtools/browser/ja/uuid-generator/index.html` 等のcanonical/hreflang/og:urlタグが末尾スラッシュなしになっていることを確認
- [x] `dist/ng-devtools/browser/sitemap.xml` の全38件のURLが末尾スラッシュなしであることを確認 (`grep "<loc>" sitemap.xml | grep -E "/$" | wc -l` → 0)
- [x] トップページ (`/ja`, `/en`) のcanonical/og:urlも正しく生成されることを確認
- [ ] デプロイ後、Search Consoleで新しいsitemapを再送信し、インデックス状況を継続モニタリング

🤖 Generated with [Claude Code](https://claude.com/claude-code)