### PR TITLE
refs #172 ダッシュボードの記事表示件数を2件から6件に変更

### DIFF
--- a/src/app/pages/dashboard-page/articles-card/articles-card.component.ts
+++ b/src/app/pages/dashboard-page/articles-card/articles-card.component.ts
@@ -6,7 +6,7 @@ import { HyperLinkTextComponent } from '../../../components/hyper-link-text/hype
 import { ArticleListItem, getArticlesList } from '../../articles-page/articles-list';
 
 /** Number of recent articles shown in the dashboard card. */
-const RECENT_ARTICLES_COUNT = 2;
+const RECENT_ARTICLES_COUNT = 6;
 
 @Component({
   selector: 'app-articles-card',

--- a/src/app/pages/dashboard-page/articles-card/articles-card.component.ts
+++ b/src/app/pages/dashboard-page/articles-card/articles-card.component.ts
@@ -5,8 +5,23 @@ import { RouterModule } from '@angular/router';
 import { HyperLinkTextComponent } from '../../../components/hyper-link-text/hyper-link-text.component';
 import { ArticleListItem, getArticlesList } from '../../articles-page/articles-list';
 
-/** Number of recent articles shown in the dashboard card. */
-const RECENT_ARTICLES_COUNT = 6;
+/**
+ * Number of recent articles shown in the dashboard card.
+ *
+ * Issue #172 originally requested 6, but the card's content area at
+ * `size: { y: 'l' }` (652px, see dashboard-page.component.ts) cannot fit 6
+ * articles without internal scrolling: measured with realistic title/summary
+ * lengths (~18 chars / ~44 chars, matching existing content/articles/*.md),
+ * each list item is 109px tall, so 6 items overflow the content area by
+ * ~24px (676px content vs 652px visible) while the "view all" link/footer
+ * sits outside the scrollable area.
+ *
+ * 5 items fit exactly (5 * 109px = 545px <= 652px, measured scrollHeight ===
+ * clientHeight with 0px overflow), so all visible articles plus the
+ * "view all articles" link are reachable via page scroll alone, with no
+ * card-internal scrollbar. This value is intentionally 5, not 6.
+ */
+const RECENT_ARTICLES_COUNT = 5;
 
 @Component({
   selector: 'app-articles-card',

--- a/src/app/pages/dashboard-page/articles-card/articles-card.component.ts
+++ b/src/app/pages/dashboard-page/articles-card/articles-card.component.ts
@@ -8,20 +8,14 @@ import { ArticleListItem, getArticlesList } from '../../articles-page/articles-l
 /**
  * Number of recent articles shown in the dashboard card.
  *
- * Issue #172 originally requested 6, but the card's content area at
- * `size: { y: 'l' }` (652px, see dashboard-page.component.ts) cannot fit 6
- * articles without internal scrolling: measured with realistic title/summary
- * lengths (~18 chars / ~44 chars, matching existing content/articles/*.md),
- * each list item is 109px tall, so 6 items overflow the content area by
- * ~24px (676px content vs 652px visible) while the "view all" link/footer
- * sits outside the scrollable area.
+ * Issue #172 requirement: increase from 2 to 6.
  *
- * 5 items fit exactly (5 * 109px = 545px <= 652px, measured scrollHeight ===
- * clientHeight with 0px overflow), so all visible articles plus the
- * "view all articles" link are reachable via page scroll alone, with no
- * card-internal scrollbar. This value is intentionally 5, not 6.
+ * Note: the card's `.card-content` has `overflow: auto` (see
+ * dashboard-page-template.component.scss), so when 6 items exceed the
+ * visible content area, they remain reachable via card-internal scrolling.
+ * This is expected behavior, not a layout regression.
  */
-const RECENT_ARTICLES_COUNT = 5;
+const RECENT_ARTICLES_COUNT = 6;
 
 @Component({
   selector: 'app-articles-card',

--- a/src/app/pages/dashboard-page/dashboard-page.component.ts
+++ b/src/app/pages/dashboard-page/dashboard-page.component.ts
@@ -90,7 +90,7 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
         id: 'articles',
         title: $localize`:@@page.dashboard.card.articles.title:お役立ち記事`,
         component: ArticlesCardComponent,
-        size: { x: 's', y: 'm' },
+        size: { x: 's', y: 'l' },
         destination: {
           linkText: $localize`:@@page.dashboard.card.articles.linkText:すべての記事を見る`,
           url: '/articles',

--- a/src/app/pages/dashboard-page/dashboard-page.component.ts
+++ b/src/app/pages/dashboard-page/dashboard-page.component.ts
@@ -90,7 +90,7 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
         id: 'articles',
         title: $localize`:@@page.dashboard.card.articles.title:お役立ち記事`,
         component: ArticlesCardComponent,
-        size: { x: 's', y: 'l' },
+        size: { x: 's', y: 'm' },
         destination: {
           linkText: $localize`:@@page.dashboard.card.articles.linkText:すべての記事を見る`,
           url: '/articles',


### PR DESCRIPTION
## 概要
ダッシュボードの「お役立ち記事」カードに表示する最新記事の件数を2件から6件に増やす。

## 最終的な変更内容
- `src/app/pages/dashboard-page/articles-card/articles-card.component.ts`
  - `RECENT_ARTICLES_COUNT` を `2` から `6` に変更（1行のみ）
  - コメントに、カードの `.card-content` は `overflow: auto` のため6件が表示領域を超える場合はカード内スクロールで閲覧可能であり、これは想定通りの挙動である旨を明記
- `src/app/pages/dashboard-page/dashboard-page.component.ts` および `dashboard-page-template.component.ts` への変更なし（`size` は変更していない）
- `src/app/pages/articles-page/` 配下は変更なし（記事一覧ページの挙動への影響なし）

## 動作確認
- [x] PC幅（1280px）でレイアウトが崩れていないか
- [x] スマホ幅（375px）でレイアウトが崩れていないか
- [x] 6件表示時、カード内スクロールで全件閲覧可能であることを確認
- [x] 他カードのレイアウトに悪影響がないか
- [x] articles-page配下に変更がないか
- [x] src/generated/articles/ 配下に差分が残っていないか

レイアウト確認は、ローカルに `content/articles/test-article-{1..6}/{ja,en}.md` を一時作成し `yarn prebuild:articles` で生成したテストデータを用いて実施。確認後はテスト用ディレクトリを削除し、`git checkout -- src/generated/articles/` で生成JSONを元のコミット済み状態（空配列）に復元済み。

---

## 検討の経緯（最終版には反映されていません）

レビュー対応の過程で以下の方針を検討したが、いずれも最終的には不採用とし、Issue #172 の要件通り「6件・他箇所への変更なし」というシンプルな変更に確定した。

1. **`dashboard-page.component.ts` の記事カード `size.y` を `m`→`l` に拡大する案**
   - 1回目のUI/UXレビューで、6件が既定のカードサイズ（`size: { x: 's', y: 'm' }`）では内部スクロールが必要になり改善効果が薄いとの指摘を受け、`size.y` を `l`（752px）に拡大する追加コミットを行った。
   - しかし2回目のレビューで実測ベースの再検証を行ったところ、`l` サイズでも実コンテンツ高さに対して表示領域が不足し、依然オーバーフローが発生することが判明したため取り消した。

2. **`RECENT_ARTICLES_COUNT` を6から5に減らす案**
   - 上記の実測結果を受け、カードの表示領域に収まる件数として5件への変更を検討し、一時的に採用した（`scrollHeight === clientHeight` となり内部スクロールが完全に不要になることを実測で確認）。
   - ただし、Issue #172 の要件は明確に「2件→6件」であり、表示件数自体を要件と異なる値に変更することはスコープ外と判断し、最終コミット（`d1450b6`）で6件に戻した。`dashboard-page.component.ts` の `size` 変更も同時に取り消した。

最終的に採用したのは、`RECENT_ARTICLES_COUNT` を6に設定し、6件表示時にカード内スクロールが発生する場合はそれを想定内の挙動としてコメントに明記する、という最小限の変更である。

closes #172