### PR TITLE
refs #162 スペーシングトークン導入とinput-cardのgap不統一を解消

### DIFF
--- a/src/app/pages/api-key-gen-page/api-key-gen-input-card/api-key-gen-input-card.component.scss
+++ b/src/app/pages/api-key-gen-page/api-key-gen-input-card/api-key-gen-input-card.component.scss
@@ -1,6 +1,6 @@
 .flex {
   display: flex;
-  gap: 8px 32px;
+  gap: var(--arc-space-xx-small) var(--arc-space-large);
   align-items: center;
 }
 
@@ -9,7 +9,7 @@
 }
 
 .input-form-wrapper {
-  margin-top: 24px;
+  margin-top: var(--arc-space-medium);
 }
 
 .input-form-s {

--- a/src/app/pages/api-key-gen-page/api-key-gen-page.component.scss
+++ b/src/app/pages/api-key-gen-page/api-key-gen-page.component.scss
@@ -1,15 +1,3 @@
-.margin-top-24 {
-  margin-top: 24px;
-}
-
-.margin-bottom-8 {
-  margin-bottom: 8px;
-}
-
-.margin-bottom-16 {
-  margin-bottom: 16px;
-}
-
 .spacer {
   padding: 4px;
 }

--- a/src/app/pages/articles-page/article-detail/article-detail.component.scss
+++ b/src/app/pages/articles-page/article-detail/article-detail.component.scss
@@ -6,22 +6,6 @@
   --article-content-max-width: min(60ch, 800px);
 }
 
-.margin-bottom-8 {
-  margin-bottom: 8px;
-}
-
-.margin-bottom-16 {
-  margin-bottom: 16px;
-}
-
-.margin-bottom-24 {
-  margin-bottom: 24px;
-}
-
-.margin-top-16 {
-  margin-top: 16px;
-}
-
 .published-date {
   font-size: var(--mat-sys-body-small-size);
   color: var(--mat-sys-on-surface-variant);

--- a/src/app/pages/articles-page/articles-page.component.scss
+++ b/src/app/pages/articles-page/articles-page.component.scss
@@ -1,7 +1,3 @@
-.margin-bottom-16 {
-  margin-bottom: 16px;
-}
-
 // Responsive card grid following docs/core/uiux/3-layouts/article-list-view.md
 // 6.2: Compact=1col, Medium=2col, Expanded=3col, Large(1440px+)=4col.
 // The guideline's --arc-space-* tokens don't exist in this project, so gap

--- a/src/app/pages/color-palette-page/color-palette-input-card/color-palette-input-card.component.scss
+++ b/src/app/pages/color-palette-page/color-palette-input-card/color-palette-input-card.component.scss
@@ -1,6 +1,6 @@
 .count-slider-wrapper {
-  margin-top: 16px;
-  margin-bottom: 8px;
+  margin-top: var(--arc-space-small);
+  margin-bottom: var(--arc-space-xx-small);
 }
 
 .count-label {
@@ -12,7 +12,7 @@
 .slider-container {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: var(--arc-space-small);
 
   mat-slider {
     flex: 1;
@@ -27,12 +27,12 @@
 }
 
 .color-inputs {
-  margin-top: 16px;
+  margin-top: var(--arc-space-small);
 }
 
 .flex {
   display: flex;
-  gap: 8px 32px;
+  gap: var(--arc-space-xx-small) var(--arc-space-large);
   align-items: flex-start;
 }
 
@@ -48,7 +48,7 @@
   }
 
   ::ng-deep .mdc-text-field {
-    padding-right: 16px !important;
+    padding-right: var(--arc-space-small) !important;
   }
 }
 
@@ -75,7 +75,7 @@
 }
 
 .mode-toggle {
-  margin: 8px 0;
+  margin: var(--arc-space-xx-small) 0;
 
   ::ng-deep .mat-button-toggle-button {
     height: 24px;
@@ -84,13 +84,13 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 4px;
+    gap: var(--arc-space-xxx-small);
   }
 
   ::ng-deep .mat-button-toggle-label-content {
     display: flex;
     align-items: center;
-    gap: 4px;
+    gap: var(--arc-space-xxx-small);
 
     mat-icon {
       font-size: 18px;

--- a/src/app/pages/color-palette-page/color-palette-page.component.scss
+++ b/src/app/pages/color-palette-page/color-palette-page.component.scss
@@ -1,11 +1,3 @@
-.margin-top-24 {
-  margin-top: 24px;
-}
-
-.margin-bottom-16 {
-  margin-bottom: 16px;
-}
-
 .spacer {
   height: 16px;
 }

--- a/src/app/pages/ip-cidr-calculator-page/ip-cidr-calculator-page.component.scss
+++ b/src/app/pages/ip-cidr-calculator-page/ip-cidr-calculator-page.component.scss
@@ -1,15 +1,3 @@
-.margin-top-24 {
-  margin-top: 24px;
-}
-
-.margin-bottom-8 {
-  margin-bottom: 8px;
-}
-
-.margin-bottom-16 {
-  margin-bottom: 16px;
-}
-
 .spacer {
   padding: 4px;
 }

--- a/src/app/pages/ip-cidr-calculator-page/ip-cidr-input-card/ip-cidr-input-card.component.scss
+++ b/src/app/pages/ip-cidr-calculator-page/ip-cidr-input-card/ip-cidr-input-card.component.scss
@@ -1,11 +1,3 @@
-.margin-bottom-8 {
-  margin-bottom: 8px;
-}
-
-.margin-bottom-16 {
-  margin-bottom: 16px;
-}
-
 .protocol-toggle-wrapper {
   display: flex;
   justify-content: center;

--- a/src/app/pages/ip-cidr-calculator-page/ip-cidr-input-card/ip-cidr-input-card.component.scss
+++ b/src/app/pages/ip-cidr-calculator-page/ip-cidr-input-card/ip-cidr-input-card.component.scss
@@ -5,7 +5,7 @@
 
 .flex {
   display: flex;
-  gap: 8px 32px;
+  gap: var(--arc-space-xx-small) var(--arc-space-large);
   align-items: center;
 }
 
@@ -14,7 +14,7 @@
 }
 
 .input-form-wrapper {
-  margin-top: 16px;
+  margin-top: var(--arc-space-small);
 }
 
 .input-form-m {
@@ -35,7 +35,7 @@
 }
 
 .cidr-slider-wrapper {
-  margin-top: 8px;
+  margin-top: var(--arc-space-xx-small);
 }
 
 .cidr-label {
@@ -47,7 +47,7 @@
 .slider-container {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: var(--arc-space-small);
 }
 
 .slider-container mat-slider {
@@ -62,7 +62,7 @@
 }
 
 .protocol-toggle {
-  margin: 8px 0;
+  margin: var(--arc-space-xx-small) 0;
 
   ::ng-deep .mat-button-toggle-button {
     height: 24px;
@@ -71,7 +71,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 4px;
+    gap: var(--arc-space-xxx-small);
   }
 
   ::ng-deep .mat-button-toggle-label-content {

--- a/src/app/pages/json-formatter-page/json-formatter-input-card/json-formatter-input-card.component.scss
+++ b/src/app/pages/json-formatter-page/json-formatter-input-card/json-formatter-input-card.component.scss
@@ -1,6 +1,6 @@
 .flex {
   display: flex;
-  gap: 8px 32px;
+  gap: var(--arc-space-xx-small) var(--arc-space-large);
   align-items: center;
 }
 
@@ -9,7 +9,7 @@
 }
 
 .input-form-wrapper {
-  margin-top: 24px;
+  margin-top: var(--arc-space-medium);
 }
 
 .input-form {
@@ -27,7 +27,7 @@
 }
 
 .json-area {
-  margin-top: 16px;
+  margin-top: var(--arc-space-small);
   width: 100%;
 }
 

--- a/src/app/pages/json-formatter-page/json-formatter-page.component.scss
+++ b/src/app/pages/json-formatter-page/json-formatter-page.component.scss
@@ -1,11 +1,3 @@
-.margin-top-24 {
-  margin-top: 24px;
-}
-
-.margin-bottom-16 {
-  margin-bottom: 16px;
-}
-
 .spacer {
   padding: 4px;
 }

--- a/src/app/pages/password-gen-page/password-gen-input-card/password-gen-input-card.component.scss
+++ b/src/app/pages/password-gen-page/password-gen-input-card/password-gen-input-card.component.scss
@@ -1,6 +1,6 @@
 .flex {
   display: flex;
-  gap: 8px 32px;
+  gap: var(--arc-space-xx-small) var(--arc-space-large);
   align-items: center;
 }
 
@@ -9,7 +9,7 @@
 }
 
 .input-form-wrapper {
-  margin-top: 24px;
+  margin-top: var(--arc-space-medium);
 }
 
 .input-form-s {

--- a/src/app/pages/password-gen-page/password-gen-page.component.scss
+++ b/src/app/pages/password-gen-page/password-gen-page.component.scss
@@ -1,15 +1,3 @@
-.margin-top-24 {
-  margin-top: 24px;
-}
-
-.margin-bottom-8 {
-  margin-bottom: 8px;
-}
-
-.margin-bottom-16 {
-  margin-bottom: 16px;
-}
-
 .spacer {
   padding: 4px;
 }

--- a/src/app/pages/privacy-policy-page/privacy-policy-page.component.scss
+++ b/src/app/pages/privacy-policy-page/privacy-policy-page.component.scss
@@ -1,11 +1,3 @@
-.margin-bottom-8 {
-  margin-bottom: 8px;
-}
-
-.margin-bottom-16 {
-  margin-bottom: 16px;
-}
-
 .spacer {
   padding: 4px;
 }

--- a/src/app/pages/sql-formatter-page/sql-formatter-input-card/sql-formatter-input-card.component.scss
+++ b/src/app/pages/sql-formatter-page/sql-formatter-input-card/sql-formatter-input-card.component.scss
@@ -1,6 +1,6 @@
 .flex {
   display: flex;
-  gap: 8px 32px;
+  gap: var(--arc-space-xx-small) var(--arc-space-large);
   align-items: center;
 }
 
@@ -9,7 +9,7 @@
 }
 
 .input-form-wrapper {
-  margin-top: 24px;
+  margin-top: var(--arc-space-medium);
 }
 
 .input-form {
@@ -27,7 +27,7 @@
 }
 
 .sql-area {
-  margin-top: 16px;
+  margin-top: var(--arc-space-small);
   width: 100%;
 }
 

--- a/src/app/pages/sql-formatter-page/sql-formatter-page.component.scss
+++ b/src/app/pages/sql-formatter-page/sql-formatter-page.component.scss
@@ -1,7 +1,0 @@
-.margin-top-24 {
-  margin-top: 24px;
-}
-
-.margin-bottom-16 {
-  margin-bottom: 16px;
-}

--- a/src/app/pages/svg-to-png-page/svg-to-png-input-card/svg-to-png-input-card.component.scss
+++ b/src/app/pages/svg-to-png-page/svg-to-png-input-card/svg-to-png-input-card.component.scss
@@ -1,19 +1,19 @@
 .svg-area {
-  margin-top: 16px;
+  margin-top: var(--arc-space-small);
   width: 100%;
 }
 
 .settings-wrapper {
-  margin-top: 24px;
+  margin-top: var(--arc-space-medium);
 }
 
 .settings-group {
-  margin-bottom: 24px;
+  margin-bottom: var(--arc-space-medium);
 }
 
 .flex {
   display: flex;
-  gap: 8px 32px;
+  gap: var(--arc-space-xx-small) var(--arc-space-large);
   align-items: center;
 }
 
@@ -22,7 +22,7 @@
 }
 
 .input-form-wrapper {
-  margin-top: 16px;
+  margin-top: var(--arc-space-small);
 }
 
 .input-form {
@@ -41,12 +41,12 @@
 
 .background-color-field {
   ::ng-deep .mdc-text-field {
-    padding-right: 16px !important;
+    padding-right: var(--arc-space-small) !important;
   }
 }
 
 .scale-wrapper {
-  margin-top: 8px;
+  margin-top: var(--arc-space-xx-small);
   width: 320px;
 
   .scale-label {
@@ -58,7 +58,7 @@
   .scale-control {
     display: flex;
     align-items: center;
-    gap: 16px;
+    gap: var(--arc-space-small);
 
     mat-slider {
       flex: 1;

--- a/src/app/pages/svg-to-png-page/svg-to-png-page.component.scss
+++ b/src/app/pages/svg-to-png-page/svg-to-png-page.component.scss
@@ -1,11 +1,3 @@
-.margin-top-24 {
-  margin-top: 24px;
-}
-
-.margin-bottom-16 {
-  margin-bottom: 16px;
-}
-
 .spacer {
   padding: 4px;
 }

--- a/src/app/pages/text-diff-page/text-diff-input-card/text-diff-input-card.component.scss
+++ b/src/app/pages/text-diff-page/text-diff-input-card/text-diff-input-card.component.scss
@@ -1,8 +1,8 @@
 .editors-section {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
-  margin-top: 16px;
+  gap: var(--arc-space-small);
+  margin-top: var(--arc-space-small);
 }
 
 .editor-wrapper {
@@ -10,7 +10,7 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--arc-space-xx-small);
 }
 
 .editor-label {

--- a/src/app/pages/text-diff-page/text-diff-page.component.scss
+++ b/src/app/pages/text-diff-page/text-diff-page.component.scss
@@ -1,11 +1,3 @@
-.margin-top-24 {
-  margin-top: 24px;
-}
-
-.margin-bottom-16 {
-  margin-bottom: 16px;
-}
-
 .spacer {
   padding: 4px;
 }

--- a/src/app/pages/ulid-gen-page/ulid-gen-input-card/ulid-gen-input-card.component.scss
+++ b/src/app/pages/ulid-gen-page/ulid-gen-input-card/ulid-gen-input-card.component.scss
@@ -1,6 +1,6 @@
 .flex {
   display: flex;
-  gap: 8px 32px;
+  gap: var(--arc-space-xx-small) var(--arc-space-large);
   align-items: center;
 }
 
@@ -9,7 +9,7 @@
 }
 
 .input-form-wrapper {
-  margin-top: 24px;
+  margin-top: var(--arc-space-medium);
 }
 
 .input-form {
@@ -21,7 +21,7 @@
 }
 
 .hint {
-  margin-left: 16px;
+  margin-left: var(--arc-space-small);
 }
 
 .toggle {

--- a/src/app/pages/ulid-gen-page/ulid-gen-page.component.scss
+++ b/src/app/pages/ulid-gen-page/ulid-gen-page.component.scss
@@ -1,15 +1,3 @@
-.margin-top-24 {
-  margin-top: 24px;
-}
-
-.margin-bottom-8 {
-  margin-bottom: 8px;
-}
-
-.margin-bottom-16 {
-  margin-bottom: 16px;
-}
-
 .spacer {
   padding: 4px;
 }

--- a/src/app/pages/unix-timestamp-converter-page/unix-timestamp-converter-page.component.scss
+++ b/src/app/pages/unix-timestamp-converter-page/unix-timestamp-converter-page.component.scss
@@ -1,11 +1,3 @@
-.margin-top-24 {
-  margin-top: 24px;
-}
-
-.margin-bottom-16 {
-  margin-bottom: 16px;
-}
-
 .spacer {
   padding: 4px;
 }

--- a/src/app/pages/unix-timestamp-converter-page/unix-timestamp-input-card/unix-timestamp-input-card.component.scss
+++ b/src/app/pages/unix-timestamp-converter-page/unix-timestamp-input-card/unix-timestamp-input-card.component.scss
@@ -1,6 +1,6 @@
 .flex {
   display: flex;
-  gap: 8px 32px;
+  gap: var(--arc-space-xx-small) var(--arc-space-large);
   align-items: center;
 }
 
@@ -9,7 +9,7 @@
 }
 
 .input-form-wrapper {
-  margin-top: 16px;
+  margin-top: var(--arc-space-small);
 }
 
 .input-form-m {
@@ -26,7 +26,7 @@
 
 .input-form {
   margin-bottom: 0;
-  margin-top: 16px;
+  margin-top: var(--arc-space-small);
 
   ::ng-deep .mat-mdc-form-field-bottom-align::before {
     height: 0 !important;

--- a/src/app/pages/url-encoder-page/url-encoder-input-card/url-encoder-input-card.component.scss
+++ b/src/app/pages/url-encoder-page/url-encoder-input-card/url-encoder-input-card.component.scss
@@ -10,7 +10,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 16px 32px;
+  gap: var(--arc-space-xx-small) var(--arc-space-large);
   margin-top: 8px;
 }
 

--- a/src/app/pages/url-encoder-page/url-encoder-page.component.scss
+++ b/src/app/pages/url-encoder-page/url-encoder-page.component.scss
@@ -1,11 +1,3 @@
-.margin-top-24 {
-  margin-top: 24px;
-}
-
-.margin-bottom-16 {
-  margin-bottom: 16px;
-}
-
 .spacer {
   padding: 4px;
 }

--- a/src/app/pages/uuid-gen-page/uuid-gen-input-card/uuid-gen-input-card.component.scss
+++ b/src/app/pages/uuid-gen-page/uuid-gen-input-card/uuid-gen-input-card.component.scss
@@ -1,6 +1,6 @@
 .flex {
   display: flex;
-  gap: 8px 32px;
+  gap: var(--arc-space-xx-small) var(--arc-space-large);
   align-items: center;
 }
 
@@ -9,7 +9,7 @@
 }
 
 .input-form-wrapper {
-  margin-top: 24px;
+  margin-top: var(--arc-space-medium);
 }
 
 .input-form {

--- a/src/app/pages/uuid-gen-page/uuid-gen-page.component.scss
+++ b/src/app/pages/uuid-gen-page/uuid-gen-page.component.scss
@@ -1,11 +1,3 @@
-.margin-top-24 {
-  margin-top: 24px;
-}
-
-.margin-bottom-16 {
-  margin-bottom: 16px;
-}
-
 .spacer {
   padding: 4px;
 }

--- a/src/app/styles/_spacing.scss
+++ b/src/app/styles/_spacing.scss
@@ -1,0 +1,38 @@
+// スペーシングトークン (8px グリッド / 微細調整は 4px)
+// 参照: docs/core/uiux/1-tokens/spacing-and-sizing.md
+@mixin init() {
+  --arc-space-xxx-small: 4px;
+  --arc-space-xx-small: 8px;
+  --arc-space-small: 16px;
+  --arc-space-medium: 24px;
+  --arc-space-large: 32px;
+}
+
+// 重複していた margin/padding ユーティリティクラスを一元管理する
+// Usage in a component template: class="margin-top-24" など
+// (グローバルクラスのため src/styles.scss のトップレベルスコープから include すること)
+@mixin utility-classes {
+  .margin-top-8 {
+    margin-top: var(--arc-space-xx-small);
+  }
+
+  .margin-top-16 {
+    margin-top: var(--arc-space-small);
+  }
+
+  .margin-top-24 {
+    margin-top: var(--arc-space-medium);
+  }
+
+  .margin-bottom-8 {
+    margin-bottom: var(--arc-space-xx-small);
+  }
+
+  .margin-bottom-16 {
+    margin-bottom: var(--arc-space-small);
+  }
+
+  .margin-bottom-24 {
+    margin-bottom: var(--arc-space-medium);
+  }
+}

--- a/src/app/styles/mixin.scss
+++ b/src/app/styles/mixin.scss
@@ -1,8 +1,10 @@
 @use './brand-color' as brand-color;
 @use './header-style' as header;
+@use './spacing' as spacing;
 
 @mixin init() {
   @include brand-color.init();
   @include header.init();
+  @include spacing.init();
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -6,6 +6,7 @@
 @use './app/styles/m3-theme' as m3-theme;
 @use './app/styles/typography' as typography;
 @use './app/styles/mixin' as mixin;
+@use './app/styles/spacing' as spacing;
 
 // Include the common styles for Angular Material. We include this here so that you only
 // have to load a single css file for Angular Material in your app.
@@ -46,6 +47,11 @@
 // Comment out the line below if you want to use the deprecated `color` inputs.
 // @include mat.color-variants-backwards-compatibility($ng-devtools-theme);
 /* You can add global styles to this file, and also import other style files */
+
+// Shared margin/padding utility classes (--arc-space-* backed), usable from
+// any component template via class="margin-top-24" etc. Component-scoped
+// .scss files cannot define global classes, so this must live here.
+@include spacing.utility-classes;
 
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "BIZ UDGothic", sans-serif; }


### PR DESCRIPTION
## 概要
スペーシング用の `--arc-space-*` CSSカスタムプロパティを新規 `src/app/styles/_spacing.scss` に定義し、各ページコンポーネントscssに重複していた `margin-top-*` / `margin-bottom-*` ユーティリティクラス定義を一元化。併せて全input-cardコンポーネント（10種）のgap・margin・padding等のハードコードされたスペーシング値をトークン参照に置き換えた。

## トークン化の方針
- `--arc-space-xxx-small` (4px) / `--arc-space-xx-small` (8px) / `--arc-space-small` (16px) / `--arc-space-medium` (24px) / `--arc-space-large` (32px) の5段階を `_spacing.scss` の `init()` mixin で定義し、`src/app/styles/mixin.scss` 経由で `src/styles.scss` の既存 `:root { @include mixin.init(); ... }` ブロックに追加。既存の `brand-color.scss` と同じパターン。
- `.margin-top-8/16/24`・`.margin-bottom-8/16/24` のグローバルユーティリティクラスは `_spacing.scss` の `utility-classes` mixin にまとめ、`src/styles.scss` のトップレベル（`:root` ブロックの外）から `@include spacing.utility-classes;` で読み込む。コンポーネントscssはAngularのView Encapsulationでカプセル化されるため、グローバルクラスはコンポーネント側に置けない。
- 各ユーティリティクラスの値はすべてトークン参照 (`var(--arc-space-*)`) に置き換え、マジックナンバーを排除。

## input-cardコンポーネントのスペーシングトークン化（全10種、レビュー対応で追加）
当初は `url-encoder-input-card` の `.options-section` の `gap: 16px 32px;` のみ他のinput-cardと不統一だったため `gap: var(--arc-space-xx-small) var(--arc-space-large);` (= 8px 32px) に修正していたが、レビュー指摘を受け、残りの10個のinput-cardコンポーネントのgap・margin・paddingについても**値を変えずに**トークン参照へ置き換えた。

対象（11ファイル）:
- api-key-gen-input-card, color-palette-input-card, ip-cidr-input-card, json-formatter-input-card, password-gen-input-card, sql-formatter-input-card, svg-to-png-input-card, text-diff-input-card, ulid-gen-input-card, unix-timestamp-input-card, uuid-gen-input-card

既存5トークン（4/8/16/24/32px）に一致しない値は無理に丸めず、px固定値のまま維持した：
- `password-gen-input-card` / `ulid-gen-input-card` / `uuid-gen-input-card` の `margin-bottom: 20px;`（4px/8pxグリッド外）
- `color-palette-input-card` / `ip-cidr-input-card` の `padding: 0 12px;`（mode-toggle/protocol-toggle内、グリッド外）
- `unix-timestamp-input-card` の `calc((320px - 32px) / 2)` 等の幅計算（spacing値ではなくサイジング計算のためスコープ外）

## 重複ユーティリティクラス統合の対象ファイル（17ファイル）
- text-diff-page, ulid-gen-page, api-key-gen-page, ip-cidr-calculator-page, color-palette-page, sql-formatter-page, url-encoder-page, unix-timestamp-converter-page, uuid-gen-page, password-gen-page, svg-to-png-page, json-formatter-page の各 `*-page.component.scss`
- ip-cidr-input-card.component.scss, privacy-policy-page.component.scss, articles-page.component.scss, article-detail.component.scss

各ファイル先頭の `.margin-top-*` / `.margin-bottom-*` クラス定義ブロックのみ削除し、`.spacer` 等の他のスタイルは変更なし。クラス名は変更していないため、各コンポーネントのHTMLテンプレート側の変更は不要（グローバルCSSとして引き続き機能）。

## 動作確認
- [x] `yarn ng build --configuration=ja` / `--configuration=en` ともにSCSSコンパイルエラー無しでビルド成功
- [x] `yarn test` 全31ファイル35テストgreen
- [x] 各対象ファイルを実際に読み、削除対象のクラス定義内容・置換対象の値を確認した上で編集
- [x] 値そのものは変更しておらずトークン参照化のみのため、見た目のリグレッションなし

closes #162