### PR TITLE
記事一覧ページの並び順を公開日の新しい順に変更

### DIFF
--- a/src/app/pages/articles-page/articles-list.spec.ts
+++ b/src/app/pages/articles-page/articles-list.spec.ts
@@ -1,0 +1,46 @@
+import { ArticleListItem, sortArticlesByPublishedDateDesc } from './articles-list';
+
+function makeArticle(slug: string, publishedDate: string): ArticleListItem {
+  return {
+    slug,
+    routerLink: `/articles/${slug}`,
+    title: slug,
+    summary: slug,
+    publishedDate,
+    relatedTools: [],
+  };
+}
+
+describe('sortArticlesByPublishedDateDesc', () => {
+  it('sorts articles by publishedDate descending (newest first)', () => {
+    const articles = [
+      makeArticle('oldest-article', '2024-01-01'),
+      makeArticle('newest-article', '2024-06-01'),
+      makeArticle('middle-article', '2024-03-01'),
+    ];
+
+    const result = sortArticlesByPublishedDateDesc(articles);
+
+    expect(result.map((article) => article.slug)).toEqual([
+      'newest-article',
+      'middle-article',
+      'oldest-article',
+    ]);
+  });
+
+  it('does not mutate the input array', () => {
+    const articles = [
+      makeArticle('oldest-article', '2024-01-01'),
+      makeArticle('newest-article', '2024-06-01'),
+    ];
+    const originalOrder = articles.map((article) => article.slug);
+
+    sortArticlesByPublishedDateDesc(articles);
+
+    expect(articles.map((article) => article.slug)).toEqual(originalOrder);
+  });
+
+  it('returns an empty array when given an empty array', () => {
+    expect(sortArticlesByPublishedDateDesc([])).toEqual([]);
+  });
+});

--- a/src/app/pages/articles-page/articles-list.ts
+++ b/src/app/pages/articles-page/articles-list.ts
@@ -27,7 +27,29 @@ export const ARTICLES_LIST_BY_LOCALE: Record<string, ArticleListItem[]> = {
   en: articlesListEn,
 };
 
-/** Returns the article list for `locale`, falling back to `ja` (source locale). */
+/**
+ * Sorts `articles` by `publishedDate` in descending order (newest first).
+ * Does not mutate the input array.
+ *
+ * Extracted as a standalone, side-effect-free function so it can be unit
+ * tested directly with fixture data, independent of the build-time
+ * generated JSON imports.
+ */
+export function sortArticlesByPublishedDateDesc(
+  articles: readonly ArticleListItem[],
+): ArticleListItem[] {
+  return [...articles].sort((a, b) => b.publishedDate.localeCompare(a.publishedDate));
+}
+
+/**
+ * Returns the article list for `locale` sorted by `publishedDate` in
+ * descending order (newest first), falling back to `ja` (source locale).
+ *
+ * Sorting is centralized here so every consumer (articles list page,
+ * dashboard articles card, etc.) shows articles in the same newest-first
+ * order without duplicating the sort logic.
+ */
 export function getArticlesList(locale: string): ArticleListItem[] {
-  return ARTICLES_LIST_BY_LOCALE[locale] ?? ARTICLES_LIST_BY_LOCALE['ja'];
+  const articles = ARTICLES_LIST_BY_LOCALE[locale] ?? ARTICLES_LIST_BY_LOCALE['ja'];
+  return sortArticlesByPublishedDateDesc(articles);
 }

--- a/src/app/pages/articles-page/articles-page.component.spec.ts
+++ b/src/app/pages/articles-page/articles-page.component.spec.ts
@@ -1,0 +1,55 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { ArticlesPageComponent } from './articles-page.component';
+
+describe('ArticlesPageComponent', () => {
+  let component: ArticlesPageComponent;
+  let fixture: ComponentFixture<ArticlesPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ArticlesPageComponent],
+      providers: [provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ArticlesPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('allArticles is sorted by publishedDate descending (newest first)', () => {
+    const dates = component.allArticles.map((article) => article.publishedDate);
+    const sortedDescending = [...dates].sort((a, b) => b.localeCompare(a));
+
+    expect(dates).toEqual(sortedDescending);
+  });
+
+  it('articles() returns a page sliced from allArticles starting at pageIndex * pageSize', () => {
+    const page = component.articles();
+    const expectedStart = component.pageIndex() * component.pageSize();
+    const expectedPage = component.allArticles.slice(
+      expectedStart,
+      expectedStart + component.pageSize(),
+    );
+
+    expect(page).toEqual(expectedPage);
+  });
+
+  it('updates pageIndex and pageSize on page change, keeping articles() consistent', () => {
+    const newPageSize = component.pageSizeOptions[0];
+
+    component.onPageChange({ pageIndex: 1, pageSize: newPageSize, length: component.allArticles.length });
+    fixture.detectChanges();
+
+    expect(component.pageIndex()).toBe(1);
+    expect(component.pageSize()).toBe(newPageSize);
+
+    const expectedStart = 1 * newPageSize;
+    const expectedPage = component.allArticles.slice(expectedStart, expectedStart + newPageSize);
+    expect(component.articles()).toEqual(expectedPage);
+  });
+});

--- a/src/app/pages/dashboard-page/articles-card/articles-card.component.ts
+++ b/src/app/pages/dashboard-page/articles-card/articles-card.component.ts
@@ -31,7 +31,8 @@ const RECENT_ARTICLES_COUNT = 6;
 export class ArticlesCardComponent {
   private readonly locale = inject(LOCALE_ID);
 
-  readonly articles: ArticleListItem[] = [...getArticlesList(this.locale)]
-    .sort((a, b) => b.publishedDate.localeCompare(a.publishedDate))
-    .slice(0, RECENT_ARTICLES_COUNT);
+  readonly articles: ArticleListItem[] = getArticlesList(this.locale).slice(
+    0,
+    RECENT_ARTICLES_COUNT,
+  );
 }


### PR DESCRIPTION
## Summary
- Issue #177 対応: 記事一覧ページ（`/articles`）が公開日の新しい順（降順）で表示されるように変更
- `getArticlesList()`（`src/app/pages/articles-page/articles-list.ts`）内でソートを一元化し、記事一覧ページとダッシュボードの記事カード（`articles-card.component.ts`）の両方が同じ並び順ロジックを共有するようにした
- `articles-card.component.ts` 側にあった重複ソートロジック（`.sort((a, b) => b.publishedDate.localeCompare(a.publishedDate))`）を削除し、`getArticlesList()` の結果をそのまま利用するように変更
- ページング（`pageIndex`/`pageSize` による slice）のロジックは変更なし

## Test plan
- [x] `yarn test` で既存テストがすべて通過することを確認（33 spec ファイル / 42 テスト）
- [x] 新規ユニットテストを追加
  - `src/app/pages/articles-page/articles-list.spec.ts`: 抽出した純粋関数 `sortArticlesByPublishedDateDesc` が公開日の降順でソートし、入力配列を破壊しないことを検証
  - `src/app/pages/articles-page/articles-page.component.spec.ts`: `allArticles` が公開日降順であること、`articles()` が `pageIndex`/`pageSize` に基づいて正しくスライスされること、ページ変更時も整合性が保たれることを検証
- [x] `node scripts/prebuild-articles.mjs` で実データを生成し、記事一覧が新しい順（leap-seconds-unix-time, uuid-v4-vs-v7 ともに同日のため要確認だが日付降順は維持）で並ぶことをローカルで確認（生成物はコミット対象外のため元に戻し済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)