### PR TITLE
refs #176 SidenavComponentのNG0100エラーを修正

### DIFF
--- a/src/app/components/sidenav/sidenav.component.html
+++ b/src/app/components/sidenav/sidenav.component.html
@@ -1,5 +1,5 @@
 <mat-sidenav-container class="container">
-  <mat-sidenav #sidenav class="sidenav" [mode]="mode">
+  <mat-sidenav #sidenav class="sidenav" [mode]="mode()">
     <app-sidemenu
       [topItem]="topItem()"
       [categories]="categories()"

--- a/src/app/components/sidenav/sidenav.component.ts
+++ b/src/app/components/sidenav/sidenav.component.ts
@@ -1,4 +1,4 @@
-import { Component, effect, inject, model, OnInit, viewChild } from '@angular/core';
+import { Component, computed, effect, inject, model, OnInit, signal, viewChild } from '@angular/core';
 import { MatDrawerMode, MatSidenav, MatSidenavModule } from '@angular/material/sidenav';
 import { SidemenuComponent } from '../sidemenu/sidemenu.component';
 import { SidemenuCategoryModel, SidemenuItemModel } from '../sidemenu/sidemenu-model';
@@ -50,6 +50,12 @@ export class SidenavComponent implements OnInit {
   /** Items rendered at the bottom of the sidenav, outside the accordion. */
   readonly bottomItems: SidemenuItemModel[] = [this.articlesItem, this.privacyPolicyItem, this.operatorInfoItem];
 
+  /** Current viewport width, kept in sync with the `resize` event. Initialized lazily to avoid NG0100. */
+  private readonly innerWidth = signal(this.platformService.window?.innerWidth ?? 0);
+
+  /** Drawer mode derived from the viewport width signal so changes flow through Angular's reactivity. */
+  readonly mode = computed<MatDrawerMode>(() => (this.innerWidth() < 600 ? 'over' : 'side'));
+
   constructor() {
     effect(() => {
       const nav = this.sidenav();
@@ -66,6 +72,7 @@ export class SidenavComponent implements OnInit {
     this.setVhVariable();
     this.platformService.window?.addEventListener('resize', () => {
       this.setVhVariable();
+      this.innerWidth.set(this.platformService.window?.innerWidth ?? 0);
     });
   }
 
@@ -76,10 +83,6 @@ export class SidenavComponent implements OnInit {
         this.sidenav()?.close();
       }
     }, 100);
-  }
-
-  get mode(): MatDrawerMode {
-    return (this.platformService.window?.innerWidth ?? 0) < 600 ? 'over' : 'side';
   }
 
   private setVhVariable(): void {


### PR DESCRIPTION
## 概要
`SidenavComponent`（`src/app/components/sidenav/`）で発生していた`NG0100`（ExpressionChangedAfterItHasBeenCheckedError）を修正する。

Issue #162のPR #175レビュー中に発見された、PR #175とは無関係な既存バグ。

## 原因
`mode` がgetterとして実装されており、テンプレートで `[mode]="mode"` と直接バインドされていた。

```ts
get mode(): MatDrawerMode {
  return (this.platformService.window?.innerWidth ?? 0) < 600 ? 'over' : 'side';
}
```

getterはAngularの変更検知のたびに再評価されるため、`window.innerWidth` の値がCDサイクル中に変化するタイミング（hydration直後やresizeイベント発火時）で異なる値を返し、`NG0100`を引き起こしていた。`innerWidth` の変化がAngularの変更検知に通知される仕組みになっていなかったことが根本原因。

## 変更点
- `src/app/components/sidenav/sidenav.component.ts`
  - `mode` のgetterを廃止し、`innerWidth` を保持する `signal` を導入
  - `mode` を `computed()` で `innerWidth` signalから導出するように変更
  - `resize` イベントハンドラ内で `innerWidth` signalを更新するように変更（既存の `setVhVariable()` 呼び出しはそのまま維持）
- `src/app/components/sidenav/sidenav.component.html`
  - `[mode]="mode"` → `[mode]="mode()"` （signal呼び出しに変更）

`PlatformService` の既存の使い方（`window?.innerWidth` のnullセーフなアクセス）はそのまま踏襲しており、SSG（Node.js環境）でも安全に動作する。

## 動作確認
- [x] `yarn start` で起動し、Playwright経由でトップページ・`/json-formatter` 等の複数ページに遷移してブラウザコンソールに`NG0100`が出力されないことを確認
- [x] ビューポートを1280px → 375px → 1280pxとリサイズしてコンソールにエラーが出ないことを確認
- [x] サイドナビのメニュー開閉ボタンをクリックして動作することを確認
- [x] `yarn test` で既存テスト全件（33ファイル / 42テスト）がパスすることを確認
- [x] 画面構成・既存コンポーネント構成は変更なし（`SidenavComponent`内部の状態管理のみ修正）

closes #176