### PR TITLE
ガイド/運営者情報/プライバシーポリシーページをUI/UXガイドラインに準拠

### DIFF
--- a/src/app/pages/guide-page/guide-page.component.html
+++ b/src/app/pages/guide-page/guide-page.component.html
@@ -1,108 +1,182 @@
 <app-application-page-template>
-  <div class="margin-bottom-16">
+  <div class="guide-layout">
     <app-heading headingType="h2" i18n="@@page.guide.title">ご利用ガイド</app-heading>
+
+    @if (isCompact()) {
+      <button
+        type="button"
+        class="guide-layout__toc-toggle"
+        (click)="isTocDrawerOpen.set(!isTocDrawerOpen())"
+        aria-label="目次を表示"
+        i18n-aria-label="@@page.guide.toc.toggleLabel"
+      >
+        <mat-icon>menu_book</mat-icon>
+        <span i18n="@@page.guide.toc.toggleText">目次を表示</span>
+      </button>
+    }
+
+    <div class="guide-layout__body">
+      @if (!isCompact()) {
+        <!-- Expanded (840px+): ToC fixed to the left, sticky while the page scrolls. -->
+        <ng-container [ngTemplateOutlet]="tocNav"></ng-container>
+      }
+
+      <article class="guide-content" #articleRef>
+        <p i18n="@@page.guide.description">devTools が提供する各ツールについて、どんな場面で使えるかを簡単に紹介します。詳しい使い方や仕様は各ツールのページをご覧ください。</p>
+
+        <p class="guide-articles-link" i18n="@@page.guide.articlesLink.intro">
+          UUIDのバージョン選定やUNIX時間の仕組みなど、ツールの使い方を超えたトピックの解説は
+        </p>
+        <app-hyper-link-text url="/articles" i18n="@@page.guide.articlesLink.cta">記事一覧</app-hyper-link-text>
+
+        <section id="sql-formatter" class="guide-item" #sectionRef>
+          <app-heading headingType="h3" i18n="@@page.guide.section.sqlFormatter">SQL整形ツール</app-heading>
+          <p i18n="@@page.guide.intro.sqlFormatter">
+            本番DBから取得したワンライナーのSQLや、ORMが生成した読みにくいクエリを、インデント付きで整形します。レビュー前の整形や、ログに残ったクエリの確認作業に活用できます。
+          </p>
+          <app-hyper-link-text url="/sql-formatter" i18n="@@page.guide.link.sqlFormatter">SQL整形ツールを使ってみる</app-hyper-link-text>
+        </section>
+
+        <mat-divider></mat-divider>
+
+        <section id="json-formatter" class="guide-item" #sectionRef>
+          <app-heading headingType="h3" i18n="@@page.guide.section.jsonFormatter">JSON整形ツール</app-heading>
+          <p i18n="@@page.guide.intro.jsonFormatter">
+            APIレスポンスや設定ファイルなど、改行のないJSON文字列を見やすい階層構造に整形します。レスポンス内容の確認やデバッグ時の目視チェックに役立ちます。
+          </p>
+          <app-hyper-link-text url="/json-formatter" i18n="@@page.guide.link.jsonFormatter">JSON整形ツールを使ってみる</app-hyper-link-text>
+        </section>
+
+        <mat-divider></mat-divider>
+
+        <section id="api-key-gen" class="guide-item" #sectionRef>
+          <app-heading headingType="h3" i18n="@@page.guide.section.apiKeyGen">APIキー生成ツール</app-heading>
+          <p i18n="@@page.guide.intro.apiKeyGen">
+            開発環境用のダミーAPIキーや、MCPサーバーの設定に使う識別子を手軽に生成します。本番発行前の動作確認やサンプルコード作成に利用できます。
+          </p>
+          <app-hyper-link-text url="/api-key-generator" i18n="@@page.guide.link.apiKeyGen">APIキー生成ツールを使ってみる</app-hyper-link-text>
+        </section>
+
+        <mat-divider></mat-divider>
+
+        <section id="password-gen" class="guide-item" #sectionRef>
+          <app-heading headingType="h3" i18n="@@page.guide.section.passwordGen">パスワード生成ツール</app-heading>
+          <p i18n="@@page.guide.intro.passwordGen">
+            文字種や桁数を指定して、推測されにくいランダムパスワードを生成します。新規サービスの初期パスワードやテストアカウント作成時に活用できます。
+          </p>
+          <app-hyper-link-text url="/password-generator" i18n="@@page.guide.link.passwordGen">パスワード生成ツールを使ってみる</app-hyper-link-text>
+        </section>
+
+        <mat-divider></mat-divider>
+
+        <section id="color-palette" class="guide-item" #sectionRef>
+          <app-heading headingType="h3" i18n="@@page.guide.section.colorPalette">カラーパレット</app-heading>
+          <p i18n="@@page.guide.intro.colorPalette">
+            ベースカラーから配色パターンやグラデーションを作成し、コードへの貼り付け用にカラーコードへ変換します。UIデザインの配色検討や既存サイトの配色確認に使えます。
+          </p>
+          <app-hyper-link-text url="/color-palette" i18n="@@page.guide.link.colorPalette">カラーパレットを使ってみる</app-hyper-link-text>
+        </section>
+
+        <mat-divider></mat-divider>
+
+        <section id="uuid-gen" class="guide-item" #sectionRef>
+          <app-heading headingType="h3" i18n="@@page.guide.section.uuidGen">UUID生成ツール</app-heading>
+          <p i18n="@@page.guide.intro.uuidGen">
+            v1/v4/v7形式のUUIDをまとめて生成します。DBの主キー設計やAPIのリクエストIDのサンプルデータ作成に便利です。
+          </p>
+          <app-hyper-link-text url="/uuid-generator" i18n="@@page.guide.link.uuidGen">UUID生成ツールを使ってみる</app-hyper-link-text>
+        </section>
+
+        <mat-divider></mat-divider>
+
+        <section id="ulid-gen" class="guide-item" #sectionRef>
+          <app-heading headingType="h3" i18n="@@page.guide.section.ulidGen">ULID生成ツール</app-heading>
+          <p i18n="@@page.guide.intro.ulidGen">
+            時系列でソート可能なULIDを生成します。ログIDやイベントIDのように、発生順序を保持したい識別子が必要な場面で活用できます。
+          </p>
+          <app-hyper-link-text url="/ulid-generator" i18n="@@page.guide.link.ulidGen">ULID生成ツールを使ってみる</app-hyper-link-text>
+        </section>
+
+        <mat-divider></mat-divider>
+
+        <section id="unix-timestamp" class="guide-item" #sectionRef>
+          <app-heading headingType="h3" i18n="@@page.guide.section.unixTimestamp">UNIXタイム変換</app-heading>
+          <p i18n="@@page.guide.intro.unixTimestamp">
+            UNIXタイムスタンプと日時表記を相互に変換します。APIレスポンスに含まれる時刻の確認や、ログの発生時刻を人が読める形式に直す際に役立ちます。
+          </p>
+          <app-hyper-link-text url="/unix-timestamp-converter" i18n="@@page.guide.link.unixTimestamp">UNIXタイム変換ツールを使ってみる</app-hyper-link-text>
+        </section>
+
+        <mat-divider></mat-divider>
+
+        <section id="url-encoder" class="guide-item" #sectionRef>
+          <app-heading headingType="h3" i18n="@@page.guide.section.urlEncoder">URLエンコード・デコードツール</app-heading>
+          <p i18n="@@page.guide.intro.urlEncoder">
+            URLに含まれる日本語や記号をパーセントエンコードし、逆にエンコード済み文字列を元の文字列へ戻します。クエリパラメータの確認やリンク作成時のトラブルシューティングに使えます。
+          </p>
+          <app-hyper-link-text url="/url-encoder" i18n="@@page.guide.link.urlEncoder">URLエンコード・デコードツールを使ってみる</app-hyper-link-text>
+        </section>
+
+        <mat-divider></mat-divider>
+
+        <section id="text-diff" class="guide-item" #sectionRef>
+          <app-heading headingType="h3" i18n="@@page.guide.section.textDiff">テキスト比較ツール</app-heading>
+          <p i18n="@@page.guide.intro.textDiff">
+            2つのテキストを並べて、追加・削除された行を色分け表示します。設定ファイルの変更箇所の確認や、文章の修正前後の差分チェックに活用できます。
+          </p>
+          <app-hyper-link-text url="/text-diff" i18n="@@page.guide.link.textDiff">テキスト比較ツールを使ってみる</app-hyper-link-text>
+        </section>
+
+        <mat-divider></mat-divider>
+
+        <section id="svg-viewer" class="guide-item" #sectionRef>
+          <app-heading headingType="h3" i18n="@@page.guide.section.svgViewer">SVGビューアー</app-heading>
+          <p i18n="@@page.guide.intro.svgViewer">
+            SVGファイルをブラウザ上でプレビューし、PNGなどの画像形式へ変換します。アイコン素材の確認や、SVGをラスター画像として書き出したい場面で役立ちます。
+          </p>
+          <app-hyper-link-text url="/svg-to-png" i18n="@@page.guide.link.svgViewer">SVGビューアーを使ってみる</app-hyper-link-text>
+        </section>
+
+        <mat-divider></mat-divider>
+
+        <section id="ip-cidr" class="guide-item" #sectionRef>
+          <app-heading headingType="h3" i18n="@@page.guide.section.ipCidr">IP/CIDR計算機</app-heading>
+          <p i18n="@@page.guide.intro.ipCidr">
+            IPアドレスとCIDR表記からネットワークアドレスやホスト数などの情報を計算します。サブネット設計やネットワーク構成の確認作業に活用できます。
+          </p>
+          <app-hyper-link-text url="/ip-cidr-calculator" i18n="@@page.guide.link.ipCidr">IP/CIDR計算機を使ってみる</app-hyper-link-text>
+        </section>
+      </article>
+    </div>
   </div>
-
-  <p i18n="@@page.guide.description">devTools が提供する各ツールについて、どんな場面で使えるかを簡単に紹介します。詳しい使い方や仕様は各ツールのページをご覧ください。</p>
-
-  <p class="guide-articles-link" i18n="@@page.guide.articlesLink.intro">
-    UUIDのバージョン選定やUNIX時間の仕組みなど、ツールの使い方を超えたトピックの解説は
-  </p>
-  <app-hyper-link-text url="/articles" i18n="@@page.guide.articlesLink.cta">記事一覧</app-hyper-link-text>
-
-  <section class="guide-item">
-    <app-heading headingType="h3" i18n="@@page.guide.section.sqlFormatter">SQL整形ツール</app-heading>
-    <p i18n="@@page.guide.intro.sqlFormatter">
-      本番DBから取得したワンライナーのSQLや、ORMが生成した読みにくいクエリを、インデント付きで整形します。レビュー前の整形や、ログに残ったクエリの確認作業に活用できます。
-    </p>
-    <app-hyper-link-text url="/sql-formatter" i18n="@@page.guide.link.sqlFormatter">SQL整形ツールを使ってみる</app-hyper-link-text>
-  </section>
-
-  <section class="guide-item">
-    <app-heading headingType="h3" i18n="@@page.guide.section.jsonFormatter">JSON整形ツール</app-heading>
-    <p i18n="@@page.guide.intro.jsonFormatter">
-      APIレスポンスや設定ファイルなど、改行のないJSON文字列を見やすい階層構造に整形します。レスポンス内容の確認やデバッグ時の目視チェックに役立ちます。
-    </p>
-    <app-hyper-link-text url="/json-formatter" i18n="@@page.guide.link.jsonFormatter">JSON整形ツールを使ってみる</app-hyper-link-text>
-  </section>
-
-  <section class="guide-item">
-    <app-heading headingType="h3" i18n="@@page.guide.section.apiKeyGen">APIキー生成ツール</app-heading>
-    <p i18n="@@page.guide.intro.apiKeyGen">
-      開発環境用のダミーAPIキーや、MCPサーバーの設定に使う識別子を手軽に生成します。本番発行前の動作確認やサンプルコード作成に利用できます。
-    </p>
-    <app-hyper-link-text url="/api-key-generator" i18n="@@page.guide.link.apiKeyGen">APIキー生成ツールを使ってみる</app-hyper-link-text>
-  </section>
-
-  <section class="guide-item">
-    <app-heading headingType="h3" i18n="@@page.guide.section.passwordGen">パスワード生成ツール</app-heading>
-    <p i18n="@@page.guide.intro.passwordGen">
-      文字種や桁数を指定して、推測されにくいランダムパスワードを生成します。新規サービスの初期パスワードやテストアカウント作成時に活用できます。
-    </p>
-    <app-hyper-link-text url="/password-generator" i18n="@@page.guide.link.passwordGen">パスワード生成ツールを使ってみる</app-hyper-link-text>
-  </section>
-
-  <section class="guide-item">
-    <app-heading headingType="h3" i18n="@@page.guide.section.colorPalette">カラーパレット</app-heading>
-    <p i18n="@@page.guide.intro.colorPalette">
-      ベースカラーから配色パターンやグラデーションを作成し、コードへの貼り付け用にカラーコードへ変換します。UIデザインの配色検討や既存サイトの配色確認に使えます。
-    </p>
-    <app-hyper-link-text url="/color-palette" i18n="@@page.guide.link.colorPalette">カラーパレットを使ってみる</app-hyper-link-text>
-  </section>
-
-  <section class="guide-item">
-    <app-heading headingType="h3" i18n="@@page.guide.section.uuidGen">UUID生成ツール</app-heading>
-    <p i18n="@@page.guide.intro.uuidGen">
-      v1/v4/v7形式のUUIDをまとめて生成します。DBの主キー設計やAPIのリクエストIDのサンプルデータ作成に便利です。
-    </p>
-    <app-hyper-link-text url="/uuid-generator" i18n="@@page.guide.link.uuidGen">UUID生成ツールを使ってみる</app-hyper-link-text>
-  </section>
-
-  <section class="guide-item">
-    <app-heading headingType="h3" i18n="@@page.guide.section.ulidGen">ULID生成ツール</app-heading>
-    <p i18n="@@page.guide.intro.ulidGen">
-      時系列でソート可能なULIDを生成します。ログIDやイベントIDのように、発生順序を保持したい識別子が必要な場面で活用できます。
-    </p>
-    <app-hyper-link-text url="/ulid-generator" i18n="@@page.guide.link.ulidGen">ULID生成ツールを使ってみる</app-hyper-link-text>
-  </section>
-
-  <section class="guide-item">
-    <app-heading headingType="h3" i18n="@@page.guide.section.unixTimestamp">UNIXタイム変換</app-heading>
-    <p i18n="@@page.guide.intro.unixTimestamp">
-      UNIXタイムスタンプと日時表記を相互に変換します。APIレスポンスに含まれる時刻の確認や、ログの発生時刻を人が読める形式に直す際に役立ちます。
-    </p>
-    <app-hyper-link-text url="/unix-timestamp-converter" i18n="@@page.guide.link.unixTimestamp">UNIXタイム変換ツールを使ってみる</app-hyper-link-text>
-  </section>
-
-  <section class="guide-item">
-    <app-heading headingType="h3" i18n="@@page.guide.section.urlEncoder">URLエンコード・デコードツール</app-heading>
-    <p i18n="@@page.guide.intro.urlEncoder">
-      URLに含まれる日本語や記号をパーセントエンコードし、逆にエンコード済み文字列を元の文字列へ戻します。クエリパラメータの確認やリンク作成時のトラブルシューティングに使えます。
-    </p>
-    <app-hyper-link-text url="/url-encoder" i18n="@@page.guide.link.urlEncoder">URLエンコード・デコードツールを使ってみる</app-hyper-link-text>
-  </section>
-
-  <section class="guide-item">
-    <app-heading headingType="h3" i18n="@@page.guide.section.textDiff">テキスト比較ツール</app-heading>
-    <p i18n="@@page.guide.intro.textDiff">
-      2つのテキストを並べて、追加・削除された行を色分け表示します。設定ファイルの変更箇所の確認や、文章の修正前後の差分チェックに活用できます。
-    </p>
-    <app-hyper-link-text url="/text-diff" i18n="@@page.guide.link.textDiff">テキスト比較ツールを使ってみる</app-hyper-link-text>
-  </section>
-
-  <section class="guide-item">
-    <app-heading headingType="h3" i18n="@@page.guide.section.svgViewer">SVGビューアー</app-heading>
-    <p i18n="@@page.guide.intro.svgViewer">
-      SVGファイルをブラウザ上でプレビューし、PNGなどの画像形式へ変換します。アイコン素材の確認や、SVGをラスター画像として書き出したい場面で役立ちます。
-    </p>
-    <app-hyper-link-text url="/svg-to-png" i18n="@@page.guide.link.svgViewer">SVGビューアーを使ってみる</app-hyper-link-text>
-  </section>
-
-  <section class="guide-item">
-    <app-heading headingType="h3" i18n="@@page.guide.section.ipCidr">IP/CIDR計算機</app-heading>
-    <p i18n="@@page.guide.intro.ipCidr">
-      IPアドレスとCIDR表記からネットワークアドレスやホスト数などの情報を計算します。サブネット設計やネットワーク構成の確認作業に活用できます。
-    </p>
-    <app-hyper-link-text url="/ip-cidr-calculator" i18n="@@page.guide.link.ipCidr">IP/CIDR計算機を使ってみる</app-hyper-link-text>
-  </section>
 </app-application-page-template>
+
+<!-- Compact (0〜599px): ToC shown as an overlay drawer toggled by the button above. -->
+@if (isCompact()) {
+  <mat-sidenav-container class="guide-toc-drawer-container" [hasBackdrop]="true">
+    <mat-sidenav
+      mode="over"
+      position="start"
+      class="guide-toc-drawer"
+      [opened]="isTocDrawerOpen()"
+      (openedChange)="isTocDrawerOpen.set($event)"
+    >
+      <ng-container [ngTemplateOutlet]="tocNav"></ng-container>
+    </mat-sidenav>
+  </mat-sidenav-container>
+}
+
+<ng-template #tocNav>
+  <nav class="guide-toc" aria-label="目次" i18n-aria-label="@@page.guide.toc.navLabel">
+    <h3 class="guide-toc__heading" i18n="@@page.guide.toc.heading">目次</h3>
+    <ul class="guide-toc__list">
+      @for (item of tocItems; track item.id) {
+        <li class="guide-toc__item" [class.guide-toc__item--active]="activeSectionId() === item.id">
+          <a class="guide-toc__link" [href]="'#' + item.id" (click)="scrollToSection(item.id, $event)">
+            {{ item.title }}
+          </a>
+        </li>
+      }
+    </ul>
+  </nav>
+</ng-template>

--- a/src/app/pages/guide-page/guide-page.component.scss
+++ b/src/app/pages/guide-page/guide-page.component.scss
@@ -1,11 +1,121 @@
+// Wiki / Manual view (ガイドページ)
+// 参照: docs/core/uiux/3-layouts/wiki-manual-view.md
+.guide-layout {
+  display: flex;
+  flex-direction: column;
+  gap: var(--arc-space-small); // 16px
+
+  &__toc-toggle {
+    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--arc-space-xxx-small); // 4px
+    padding: var(--arc-space-xx-small) var(--arc-space-small); // 8px 16px
+    border: 1px solid var(--mat-sys-outline-variant);
+    border-radius: var(--arc-shape-medium); // 4px
+    background: transparent;
+    color: var(--mat-sys-on-surface);
+    font-size: var(--mat-sys-label-large-size);
+    cursor: pointer;
+  }
+
+  &__body {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--arc-space-medium); // 24px
+  }
+}
+
+// Standalone ToC nav, reused for both the desktop sticky sidebar and the
+// mobile drawer's content (rendered via the #tocNav template).
+.guide-toc {
+  width: 240px;
+  flex: none;
+  background-color: var(--mat-sys-surface-container);
+  border-right: 1px solid var(--mat-sys-outline-variant);
+  // Sticks to the viewport as the page scrolls (the page itself has no
+  // fixed-height scroll ancestor, so a plain `position: sticky` works here).
+  position: sticky;
+  top: var(--arc-space-small); // 16px
+  max-height: calc(100vh - var(--arc-space-large));
+  overflow-y: auto;
+
+  &__heading {
+    font-size: var(--mat-sys-title-large-size);
+    font-weight: 700;
+    padding: var(--arc-space-small); // 16px
+    margin: 0;
+    position: sticky;
+    top: 0;
+    background-color: inherit;
+  }
+
+  &__list {
+    list-style: none;
+    padding: 0 var(--arc-space-xx-small); // 8px
+    margin: 0;
+  }
+
+  &__link {
+    display: block;
+    padding: var(--arc-space-xxx-small) var(--arc-space-xx-small); // 4px 8px
+    border-radius: var(--arc-shape-medium); // 4px
+    color: var(--mat-sys-on-surface);
+    text-decoration: none;
+    font-size: var(--mat-sys-body-large-size);
+    line-height: 1.6;
+
+    &:hover {
+      background-color: var(--mat-sys-surface-container-high);
+    }
+  }
+
+  &__item--active > &__link {
+    background-color: var(--mat-sys-primary-container);
+    color: var(--mat-sys-on-primary-container);
+    font-weight: 500;
+  }
+}
+
+// Mobile (Compact) drawer: an overlay-only sidenav, separate from the
+// desktop sticky `.guide-toc` instance above.
+.guide-toc-drawer-container {
+  // mat-sidenav-container normally reserves layout space and paints its own
+  // surface background; here it only hosts an overlay drawer, so it must stay
+  // visually transparent and out of the page's normal flow.
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1000;
+  background: transparent !important;
+}
+
+.guide-toc-drawer {
+  pointer-events: auto;
+
+  .guide-toc {
+    position: static;
+    max-height: 100%;
+    border-right: none;
+  }
+}
+
+.guide-content {
+  flex: 1;
+  min-width: 0;
+  max-width: var(--arc-wiki-content-max-width); // 800px
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--arc-space-medium); // 24px
+}
+
 .guide-item {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-top: 24px;
+  gap: var(--arc-space-xx-small); // 8px
 }
 
 .guide-articles-link {
-  margin-top: 16px;
-  margin-bottom: 0;
+  margin: 0;
 }

--- a/src/app/pages/guide-page/guide-page.component.ts
+++ b/src/app/pages/guide-page/guide-page.component.ts
@@ -1,7 +1,34 @@
-import { Component } from '@angular/core';
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { NgTemplateOutlet } from '@angular/common';
+import { AfterViewInit, Component, ElementRef, inject, OnDestroy, signal, viewChild, viewChildren } from '@angular/core';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSidenavModule } from '@angular/material/sidenav';
 import { ApplicationPageTemplateComponent } from '../../components/application-page-template/application-page-template.component';
 import { HeadingComponent } from '../../components/heading/heading.component';
 import { HyperLinkTextComponent } from '../../components/hyper-link-text/hyper-link-text.component';
+import { PlatformService } from '../../core/services/platform.service';
+
+export interface GuideTocItem {
+  readonly id: string;
+  readonly title: string;
+}
+
+/** Section anchors shown in the guide page's table of contents, in document order. */
+const TOC_ITEMS: readonly GuideTocItem[] = [
+  { id: 'sql-formatter', title: $localize`:@@page.guide.section.sqlFormatter:SQL整形ツール` },
+  { id: 'json-formatter', title: $localize`:@@page.guide.section.jsonFormatter:JSON整形ツール` },
+  { id: 'api-key-gen', title: $localize`:@@page.guide.section.apiKeyGen:APIキー生成ツール` },
+  { id: 'password-gen', title: $localize`:@@page.guide.section.passwordGen:パスワード生成ツール` },
+  { id: 'color-palette', title: $localize`:@@page.guide.section.colorPalette:カラーパレット` },
+  { id: 'uuid-gen', title: $localize`:@@page.guide.section.uuidGen:UUID生成ツール` },
+  { id: 'ulid-gen', title: $localize`:@@page.guide.section.ulidGen:ULID生成ツール` },
+  { id: 'unix-timestamp', title: $localize`:@@page.guide.section.unixTimestamp:UNIXタイム変換` },
+  { id: 'url-encoder', title: $localize`:@@page.guide.section.urlEncoder:URLエンコード・デコードツール` },
+  { id: 'text-diff', title: $localize`:@@page.guide.section.textDiff:テキスト比較ツール` },
+  { id: 'svg-viewer', title: $localize`:@@page.guide.section.svgViewer:SVGビューアー` },
+  { id: 'ip-cidr', title: $localize`:@@page.guide.section.ipCidr:IP/CIDR計算機` },
+];
 
 @Component({
   selector: 'app-guide-page',
@@ -9,8 +36,73 @@ import { HyperLinkTextComponent } from '../../components/hyper-link-text/hyper-l
     ApplicationPageTemplateComponent,
     HeadingComponent,
     HyperLinkTextComponent,
+    MatDividerModule,
+    MatIconModule,
+    MatSidenavModule,
+    NgTemplateOutlet,
   ],
   templateUrl: './guide-page.component.html',
   styleUrl: './guide-page.component.scss',
 })
-export class GuidePageComponent {}
+export class GuidePageComponent implements AfterViewInit, OnDestroy {
+  protected readonly tocItems = TOC_ITEMS;
+
+  protected readonly isCompact = signal(false);
+
+  /** Whether the mobile (Compact) ToC drawer is currently open. */
+  protected readonly isTocDrawerOpen = signal(false);
+
+  /** Id of the ToC entry currently highlighted by scroll-spy. */
+  protected readonly activeSectionId = signal<string | undefined>(TOC_ITEMS[0]?.id);
+
+  private readonly articleRef = viewChild<ElementRef<HTMLElement>>('articleRef');
+  private readonly sectionRefs = viewChildren<ElementRef<HTMLElement>>('sectionRef');
+
+  private readonly breakpointObserver = inject(BreakpointObserver);
+  private readonly platformService = inject(PlatformService);
+
+  private intersectionObserver?: IntersectionObserver;
+  private readonly breakpointSubscription = this.breakpointObserver
+    .observe(Breakpoints.Handset)
+    .subscribe((result) => this.isCompact.set(result.matches));
+
+  ngAfterViewInit(): void {
+    // IntersectionObserver is a browser-only API; skip it during SSG prerendering (Node.js).
+    if (!this.platformService.isBrowser()) return;
+
+    this.intersectionObserver = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.find((entry) => entry.isIntersecting);
+        if (visible?.target.id) {
+          this.activeSectionId.set(visible.target.id);
+        }
+      },
+      { rootMargin: '-20% 0px -70% 0px' },
+    );
+
+    this.sectionRefs().forEach((section) => this.intersectionObserver?.observe(section.nativeElement));
+  }
+
+  ngOnDestroy(): void {
+    this.intersectionObserver?.disconnect();
+    this.breakpointSubscription.unsubscribe();
+  }
+
+  protected scrollToSection(sectionId: string, event: MouseEvent): void {
+    event.preventDefault();
+    const scrollToTarget = () =>
+      this.articleRef()
+        ?.nativeElement.querySelector(`#${sectionId}`)
+        ?.scrollIntoView({ behavior: 'smooth' });
+
+    if (this.isTocDrawerOpen()) {
+      // Closing the mobile drawer triggers a CSS transition on the surrounding
+      // layout; defer the scroll until after that settles, otherwise the
+      // reflow cancels/overrides the smooth scroll.
+      this.isTocDrawerOpen.set(false);
+      setTimeout(scrollToTarget, 300);
+    } else {
+      scrollToTarget();
+    }
+  }
+}

--- a/src/app/pages/operator-info-page/operator-info-page.component.html
+++ b/src/app/pages/operator-info-page/operator-info-page.component.html
@@ -1,29 +1,31 @@
 <app-application-page-template>
-  <div class="margin-bottom-16">
-    <app-heading headingType="h2" i18n="@@page.operatorInfo.title">運営者情報・お問い合わせ</app-heading>
+  <div class="text-only-page">
+    <header class="text-only-page__header">
+      <app-heading headingType="h2" i18n="@@page.operatorInfo.title">運営者情報・お問い合わせ</app-heading>
+    </header>
+
+    <mat-card class="text-only-page__card" appearance="outlined">
+      <mat-card-content class="text-only-page__content">
+        <section>
+          <app-heading id="operator" headingType="h3" i18n="@@page.operatorInfo.operator.heading">運営者</app-heading>
+          <p i18n="@@page.operatorInfo.operator.body">
+            当サイトは個人（ハンドルネーム：morihara-tech）が運営しています。
+          </p>
+        </section>
+
+        <mat-divider></mat-divider>
+
+        <section>
+          <app-heading id="contact" headingType="h3" i18n="@@page.operatorInfo.contact.heading">お問い合わせ</app-heading>
+          <p i18n="@@page.operatorInfo.contact.body">
+            当サイトに関するお問い合わせ・ご意見・不具合のご報告は、GitHub Issues にてお受けしております。
+            下記リンクよりご投稿ください。
+          </p>
+          <p>
+            <app-hyper-link-text url="https://github.com/morihara-tech/ng-devtools/issues" [openInNewTab]="true" i18n="@@page.operatorInfo.contact.link">GitHub Issues で問い合わせる</app-hyper-link-text>
+          </p>
+        </section>
+      </mat-card-content>
+    </mat-card>
   </div>
-
-  <section>
-    <div class="margin-bottom-8">
-      <app-heading id="operator" headingType="h3" i18n="@@page.operatorInfo.operator.heading">運営者</app-heading>
-    </div>
-    <p i18n="@@page.operatorInfo.operator.body">
-      当サイトは個人（ハンドルネーム：morihara-tech）が運営しています。
-    </p>
-  </section>
-
-  <div class="spacer"></div>
-
-  <section>
-    <div class="margin-bottom-8">
-      <app-heading id="contact" headingType="h3" i18n="@@page.operatorInfo.contact.heading">お問い合わせ</app-heading>
-    </div>
-    <p i18n="@@page.operatorInfo.contact.body">
-      当サイトに関するお問い合わせ・ご意見・不具合のご報告は、GitHub Issues にてお受けしております。
-      下記リンクよりご投稿ください。
-    </p>
-    <p>
-      <app-hyper-link-text url="https://github.com/morihara-tech/ng-devtools/issues" [openInNewTab]="true" i18n="@@page.operatorInfo.contact.link">GitHub Issues で問い合わせる</app-hyper-link-text>
-    </p>
-  </section>
 </app-application-page-template>

--- a/src/app/pages/operator-info-page/operator-info-page.component.scss
+++ b/src/app/pages/operator-info-page/operator-info-page.component.scss
@@ -1,11 +1,4 @@
-.margin-bottom-8 {
-  margin-bottom: 8px;
-}
-
-.margin-bottom-16 {
-  margin-bottom: 16px;
-}
-
-.spacer {
-  padding: 4px;
-}
+// Text-only page view (規約・ポリシー画面)
+// 参照: docs/core/uiux/3-layouts/text-only-page-view.md
+@use '../../styles/text-only-page' as text-only-page;
+@include text-only-page.styles;

--- a/src/app/pages/operator-info-page/operator-info-page.component.ts
+++ b/src/app/pages/operator-info-page/operator-info-page.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatDividerModule } from '@angular/material/divider';
 import { ApplicationPageTemplateComponent } from '../../components/application-page-template/application-page-template.component';
 import { HeadingComponent } from '../../components/heading/heading.component';
 import { HyperLinkTextComponent } from '../../components/hyper-link-text/hyper-link-text.component';
@@ -6,7 +8,13 @@ import { HyperLinkTextComponent } from '../../components/hyper-link-text/hyper-l
 /** Displays operator information and contact details for the application. */
 @Component({
   selector: 'app-operator-info-page',
-  imports: [ApplicationPageTemplateComponent, HeadingComponent, HyperLinkTextComponent],
+  imports: [
+    ApplicationPageTemplateComponent,
+    HeadingComponent,
+    HyperLinkTextComponent,
+    MatCardModule,
+    MatDividerModule,
+  ],
   templateUrl: './operator-info-page.component.html',
   styleUrl: './operator-info-page.component.scss',
 })

--- a/src/app/pages/privacy-policy-page/privacy-policy-page.component.html
+++ b/src/app/pages/privacy-policy-page/privacy-policy-page.component.html
@@ -1,50 +1,52 @@
 <app-application-page-template>
-  <div class="margin-bottom-16">
-    <app-heading headingType="h2" i18n="@@page.privacyPolicy.title">プライバシーポリシー</app-heading>
+  <div class="text-only-page">
+    <header class="text-only-page__header">
+      <app-heading headingType="h2" i18n="@@page.privacyPolicy.title">プライバシーポリシー</app-heading>
+      <p class="text-only-page__updated-at">
+        <span i18n="@@page.privacyPolicy.updatedAtLabel">最終更新日:</span>
+        <time datetime="2026-05-09" i18n="@@page.privacyPolicy.updatedAtValue">2026/05/09</time>
+      </p>
+    </header>
+
+    <mat-card class="text-only-page__card" appearance="outlined">
+      <mat-card-content class="text-only-page__content">
+        <section>
+          <app-heading id="analytics" headingType="h3" i18n="@@page.privacyPolicy.analytics.heading">アクセス解析ツールについて</app-heading>
+          <p i18n="@@page.privacyPolicy.analytics.body">
+            当サイトでは、Google が提供するアクセス解析ツール「Google アナリティクス（GA4）」を使用しています。
+            Google アナリティクスは Cookie を使用してデータを収集します。収集されるデータは匿名であり、個人を特定するものではありません。
+            収集されたデータは Google のプライバシーポリシーに基づき管理されます。
+          </p>
+        </section>
+
+        <mat-divider></mat-divider>
+
+        <section>
+          <app-heading id="cookie-policy" headingType="h3" i18n="@@page.privacyPolicy.cookiePolicy.heading">広告の配信について（Cookie ポリシー）</app-heading>
+          <p i18n="@@page.privacyPolicy.cookiePolicy.body">
+            当サイトでは、Google AdSense を利用した広告を掲載しています。
+            Google などの第三者配信事業者は Cookie を使用して、ユーザーの興味に基づくパーソナライズ広告を表示することがあります。
+          </p>
+          <app-heading id="optout" headingType="h4" i18n="@@page.privacyPolicy.cookiePolicy.optout.heading">広告のパーソナライズを無効にする方法</app-heading>
+          <p i18n="@@page.privacyPolicy.cookiePolicy.optout.body">
+            Google 広告設定ページにアクセスすることで、パーソナライズ広告を無効にできます。
+            また、<app-hyper-link-text url="https://www.aboutads.info/choices/" [openInNewTab]="true">aboutads.info</app-hyper-link-text>
+            から第三者配信事業者の Cookie 利用を無効にすることも可能です。
+          </p>
+        </section>
+
+        <mat-divider></mat-divider>
+
+        <section>
+          <app-heading id="disclaimer" headingType="h3" i18n="@@page.privacyPolicy.disclaimer.heading">免責事項</app-heading>
+          <p i18n="@@page.privacyPolicy.disclaimer.body">
+            当サイトで提供するツールはいずれもデータをサーバーに保存しません。
+            入力されたデータはすべてブラウザ内で処理されます。
+            当サイトの内容やポリシーは予告なく変更される場合があります。
+            最新のプライバシーポリシーは常に本ページをご確認ください。
+          </p>
+        </section>
+      </mat-card-content>
+    </mat-card>
   </div>
-
-  <section>
-    <div class="margin-bottom-8">
-      <app-heading id="analytics" headingType="h3" i18n="@@page.privacyPolicy.analytics.heading">アクセス解析ツールについて</app-heading>
-    </div>
-    <p i18n="@@page.privacyPolicy.analytics.body">
-      当サイトでは、Google が提供するアクセス解析ツール「Google アナリティクス（GA4）」を使用しています。
-      Google アナリティクスは Cookie を使用してデータを収集します。収集されるデータは匿名であり、個人を特定するものではありません。
-      収集されたデータは Google のプライバシーポリシーに基づき管理されます。
-    </p>
-  </section>
-
-  <div class="spacer"></div>
-
-  <section>
-    <div class="margin-bottom-8">
-      <app-heading id="cookie-policy" headingType="h3" i18n="@@page.privacyPolicy.cookiePolicy.heading">広告の配信について（Cookie ポリシー）</app-heading>
-    </div>
-    <p i18n="@@page.privacyPolicy.cookiePolicy.body">
-      当サイトでは、Google AdSense を利用した広告を掲載しています。
-      Google などの第三者配信事業者は Cookie を使用して、ユーザーの興味に基づくパーソナライズ広告を表示することがあります。
-    </p>
-    <div class="margin-bottom-8">
-      <app-heading id="optout" headingType="h4" i18n="@@page.privacyPolicy.cookiePolicy.optout.heading">広告のパーソナライズを無効にする方法</app-heading>
-    </div>
-    <p i18n="@@page.privacyPolicy.cookiePolicy.optout.body">
-      Google 広告設定ページにアクセスすることで、パーソナライズ広告を無効にできます。
-      また、<app-hyper-link-text url="https://www.aboutads.info/choices/" [openInNewTab]="true">aboutads.info</app-hyper-link-text>
-      から第三者配信事業者の Cookie 利用を無効にすることも可能です。
-    </p>
-  </section>
-
-  <div class="spacer"></div>
-
-  <section>
-    <div class="margin-bottom-8">
-      <app-heading id="disclaimer" headingType="h3" i18n="@@page.privacyPolicy.disclaimer.heading">免責事項</app-heading>
-    </div>
-    <p i18n="@@page.privacyPolicy.disclaimer.body">
-      当サイトで提供するツールはいずれもデータをサーバーに保存しません。
-      入力されたデータはすべてブラウザ内で処理されます。
-      当サイトの内容やポリシーは予告なく変更される場合があります。
-      最新のプライバシーポリシーは常に本ページをご確認ください。
-    </p>
-  </section>
 </app-application-page-template>

--- a/src/app/pages/privacy-policy-page/privacy-policy-page.component.scss
+++ b/src/app/pages/privacy-policy-page/privacy-policy-page.component.scss
@@ -1,3 +1,4 @@
-.spacer {
-  padding: 4px;
-}
+// Text-only page view (規約・ポリシー画面)
+// 参照: docs/core/uiux/3-layouts/text-only-page-view.md
+@use '../../styles/text-only-page' as text-only-page;
+@include text-only-page.styles;

--- a/src/app/pages/privacy-policy-page/privacy-policy-page.component.ts
+++ b/src/app/pages/privacy-policy-page/privacy-policy-page.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatDividerModule } from '@angular/material/divider';
 import { ApplicationPageTemplateComponent } from '../../components/application-page-template/application-page-template.component';
 import { HeadingComponent } from '../../components/heading/heading.component';
 import { HyperLinkTextComponent } from '../../components/hyper-link-text/hyper-link-text.component';
@@ -6,7 +8,13 @@ import { HyperLinkTextComponent } from '../../components/hyper-link-text/hyper-l
 /** Displays the privacy policy content for the application. */
 @Component({
   selector: 'app-privacy-policy-page',
-  imports: [ApplicationPageTemplateComponent, HeadingComponent, HyperLinkTextComponent],
+  imports: [
+    ApplicationPageTemplateComponent,
+    HeadingComponent,
+    HyperLinkTextComponent,
+    MatCardModule,
+    MatDividerModule,
+  ],
   templateUrl: './privacy-policy-page.component.html',
   styleUrl: './privacy-policy-page.component.scss',
 })

--- a/src/app/styles/_spacing.scss
+++ b/src/app/styles/_spacing.scss
@@ -6,6 +6,20 @@
   --arc-space-small: 16px;
   --arc-space-medium: 24px;
   --arc-space-large: 32px;
+
+  // 規約・ポリシー等のテキストのみページ本文（カード）最大幅
+  // 参照: docs/core/uiux/3-layouts/text-only-page-view.md 5.1
+  --arc-text-only-content-max-width: 720px;
+
+  // Wiki・マニュアル画面（ガイドページ）本文最大幅
+  // 参照: docs/core/uiux/3-layouts/wiki-manual-view.md 5.
+  --arc-wiki-content-max-width: 800px;
+
+  // 角丸トークン (Shape / Border Radius)
+  // 参照: docs/core/uiux/1-tokens/spacing-and-sizing.md 5.1
+  --arc-shape-small: 4px;
+  --arc-shape-medium: 4px;
+  --arc-shape-large: 8px;
 }
 
 // 重複していた margin/padding ユーティリティクラスを一元管理する

--- a/src/app/styles/_text-only-page.scss
+++ b/src/app/styles/_text-only-page.scss
@@ -1,0 +1,43 @@
+// Shared layout for "text-only" static pages (privacy policy, operator info, etc.)
+// 参照: docs/core/uiux/3-layouts/text-only-page-view.md
+// Usage in a page's stylesheet:
+//   @use '../../styles/text-only-page' as text-only-page;
+//   @include text-only-page.styles;
+@mixin styles {
+  .text-only-page {
+    display: flex;
+    flex-direction: column;
+    gap: var(--arc-space-medium); // 24px
+    max-width: var(--arc-text-only-content-max-width); // 720px
+    margin-inline: auto;
+
+    &__header {
+      display: flex;
+      flex-direction: column;
+      gap: var(--arc-space-xxx-small); // 4px
+    }
+
+    &__updated-at {
+      margin: 0;
+      font-size: var(--mat-sys-label-small-size);
+      color: var(--mat-sys-on-surface-variant);
+    }
+
+    &__card {
+      border-radius: var(--arc-shape-large); // 8px
+      background-color: var(--mat-sys-surface-container-low);
+    }
+
+    &__content {
+      display: flex;
+      flex-direction: column;
+      gap: var(--arc-space-medium); // 24px
+
+      section {
+        display: flex;
+        flex-direction: column;
+        gap: var(--arc-space-xx-small); // 8px
+      }
+    }
+  }
+}

--- a/src/resources/texts/def/messages.en.xlf
+++ b/src/resources/texts/def/messages.en.xlf
@@ -811,6 +811,30 @@
         <target>User Guide</target>
       </segment>
     </unit>
+    <unit id="page.guide.toc.heading">
+      <segment state="translated">
+        <source>目次</source>
+        <target>Contents</target>
+      </segment>
+    </unit>
+    <unit id="page.guide.toc.navLabel">
+      <segment state="translated">
+        <source>目次</source>
+        <target>Table of contents</target>
+      </segment>
+    </unit>
+    <unit id="page.guide.toc.toggleLabel">
+      <segment state="translated">
+        <source>目次を表示</source>
+        <target>Show table of contents</target>
+      </segment>
+    </unit>
+    <unit id="page.guide.toc.toggleText">
+      <segment state="translated">
+        <source>目次を表示</source>
+        <target>Contents</target>
+      </segment>
+    </unit>
     <unit id="page.ipCidr.card.input.cidr">
       <segment state="initial">
         <source>CIDR</source>
@@ -3506,6 +3530,18 @@ Added the tool list page.</target>
       <segment state="initial">
         <source>プライバシーポリシー</source>
         <target>Privacy Policy</target>
+      </segment>
+    </unit>
+    <unit id="page.privacyPolicy.updatedAtLabel">
+      <segment state="translated">
+        <source>最終更新日:</source>
+        <target>Last updated:</target>
+      </segment>
+    </unit>
+    <unit id="page.privacyPolicy.updatedAtValue">
+      <segment state="translated">
+        <source>2026/05/09</source>
+        <target>May 9, 2026</target>
       </segment>
     </unit>
     <unit id="page.privacyPolicy.analytics.heading">

--- a/src/resources/texts/def/messages.xlf
+++ b/src/resources/texts/def/messages.xlf
@@ -676,6 +676,26 @@
         <source>ご利用ガイド</source>
       </segment>
     </unit>
+    <unit id="page.guide.toc.heading">
+      <segment>
+        <source>目次</source>
+      </segment>
+    </unit>
+    <unit id="page.guide.toc.navLabel">
+      <segment>
+        <source>目次</source>
+      </segment>
+    </unit>
+    <unit id="page.guide.toc.toggleLabel">
+      <segment>
+        <source>目次を表示</source>
+      </segment>
+    </unit>
+    <unit id="page.guide.toc.toggleText">
+      <segment>
+        <source>目次を表示</source>
+      </segment>
+    </unit>
     <unit id="page.ipCidr.card.input.cidr">
       <segment>
         <source>CIDR</source>
@@ -2917,6 +2937,16 @@ UNIXタイム変換ツールを実装しました。</source>
     <unit id="page.privacyPolicy.title">
       <segment>
         <source>プライバシーポリシー</source>
+      </segment>
+    </unit>
+    <unit id="page.privacyPolicy.updatedAtLabel">
+      <segment>
+        <source>最終更新日:</source>
+      </segment>
+    </unit>
+    <unit id="page.privacyPolicy.updatedAtValue">
+      <segment>
+        <source>2026/05/09</source>
       </segment>
     </unit>
     <unit id="page.privacyPolicy.analytics.heading">


### PR DESCRIPTION
## Summary
- ガイドページ・運営者情報ページ・プライバシーポリシーページを doc-arc の UI/UX ガイドライン（`text-only-page-view.md` / `wiki-manual-view.md`）に準拠させた
- 本文を `mat-card` でカード化し `--mat-sys-surface-container-low` 等の Surface トークンを適用
- 本文最大幅を制限（プライバシーポリシー/運営者情報: `--arc-text-only-content-max-width`=720px、ガイドページ: `--arc-wiki-content-max-width`=800px、いずれも新規トークンとして `_spacing.scss` に定義）
- `padding:4px` 等のマジックナンバー・`.spacer` div を `--arc-space-*` トークンと `mat-divider` に置き換え
- ガイドページ（セクション数13）に ToC + スクロールスパイを実装（IntersectionObserver、デスクトップは sticky 表示、モバイルは `mat-sidenav` ドロワー。SSGビルド時は `PlatformService.isBrowser()` でガード）
- プライバシーポリシーページに最終更新日表示（H1直下）を追加
- 本文テキスト・情報内容は変更していない（レイアウト・スタイルのみ）

## Test plan
- [x] `yarn build`（ja/en両ロケール）が成功することを確認
- [x] `yarn test` が全件パス（33 files / 42 tests）することを確認
- [x] Playwright でガイドページのデスクトップ表示（ToCサイドバー・sticky・スクロールスパイのハイライト）を確認
- [x] Playwright でガイドページのモバイル表示（375px、ToCドロワーの開閉・リンククリックでのスクロール）を確認
- [x] Playwright でプライバシーポリシー・運営者情報ページのカード化レイアウトを確認

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)