### PR TITLE
refs #183 UUIDジェネレーターのヘルプ概要文の上限件数表記を修正

### DIFF
--- a/src/app/pages/uuid-gen-page/uuid-gen-help/uuid-gen-help.component.html
+++ b/src/app/pages/uuid-gen-page/uuid-gen-help/uuid-gen-help.component.html
@@ -2,7 +2,7 @@
   <app-help-section icon="info">
     <span helpTitle i18n="@@uuidGenHelpOverview">概要</span>
     <p class="help-text" i18n="@@uuidGenHelpOverviewDesc">
-      UUIDジェネレーターは、RFC 4122（RFC 9562）に準拠したUniversally Unique Identifier（UUID）をオンラインで生成するツールです。v1・v4・v7の3バージョンに対応し、最大100件の一括生成が可能です。
+      UUIDジェネレーターは、RFC 4122（RFC 9562）に準拠したUniversally Unique Identifier（UUID）をオンラインで生成するツールです。v1・v4・v7の3バージョンに対応し、最大1,000件の一括生成が可能です。
     </p>
   </app-help-section>
 

--- a/src/resources/texts/def/messages.en.xlf
+++ b/src/resources/texts/def/messages.en.xlf
@@ -3763,7 +3763,7 @@ Added the tool list page.</target>
     </unit>
     <unit id="uuidGenHelpOverviewDesc">
       <segment state="initial">
-        <source> UUIDジェネレーターは、RFC 4122（RFC 9562）に準拠したUniversally Unique Identifier（UUID）をオンラインで生成するツールです。v1・v4・v7の3バージョンに対応し、最大100件の一括生成が可能です。 </source>
+        <source> UUIDジェネレーターは、RFC 4122（RFC 9562）に準拠したUniversally Unique Identifier（UUID）をオンラインで生成するツールです。v1・v4・v7の3バージョンに対応し、最大1,000件の一括生成が可能です。 </source>
         <target>Writing one-off test fixtures or seeding a database with sample primary keys shouldn&apos;t require spinning up a script just to call a UUID library. This generator produces RFC 9562-compliant UUIDs directly in the browser — choose from the classic random v4, the timestamp-based v1, or the newer time-ordered v7 — and can output up to 1,000 at once for bulk seeding.</target>
       </segment>
     </unit>

--- a/src/resources/texts/def/messages.xlf
+++ b/src/resources/texts/def/messages.xlf
@@ -3126,7 +3126,7 @@ UNIXタイム変換ツールを実装しました。</source>
     </unit>
     <unit id="uuidGenHelpOverviewDesc">
       <segment>
-        <source> UUIDジェネレーターは、RFC 4122（RFC 9562）に準拠したUniversally Unique Identifier（UUID）をオンラインで生成するツールです。v1・v4・v7の3バージョンに対応し、最大100件の一括生成が可能です。 </source>
+        <source> UUIDジェネレーターは、RFC 4122（RFC 9562）に準拠したUniversally Unique Identifier（UUID）をオンラインで生成するツールです。v1・v4・v7の3バージョンに対応し、最大1,000件の一括生成が可能です。 </source>
       </segment>
     </unit>
     <unit id="uuidGenHelpSpec">


### PR DESCRIPTION
## Summary
- UUIDジェネレーターのヘルプ概要文（`uuidGenHelpOverviewDesc`）にあった「最大100件」という古い表記を「最大1,000件」に修正
- 実装（`Validators.max(1000)`）および同ヘルプの使い方セクション（`uuidGenHelpUsageStep2`）は既に1,000件で正しく、概要文だけが古いままだった
- en版の `<target>` はPR #181で既に "up to 1,000" として修正済みのため変更不要（確認済み）
- `yarn ng extract-i18n` を実行し、ja/en両方のxlfが正しく同期されていることを確認

## Test plan
- [x] `src/app/pages/uuid-gen-page/uuid-gen-help/uuid-gen-help.component.html` のja文言を確認
- [x] `messages.xlf` / `messages.en.xlf` がextract-i18n後も一致していることを確認
- [x] `grep -n '<target/>' src/resources/texts/def/messages.en.xlf` で未翻訳なしを確認

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)