### PR TITLE
refs #188 お役立ち記事カードのタイトル重なりと本文見切れを修正

### DIFF
--- a/src/app/components/dashboard/dashboard-page-template/dashboard-page-template.component.scss
+++ b/src/app/components/dashboard/dashboard-page-template/dashboard-page-template.component.scss
@@ -50,6 +50,23 @@
 .card-content {
   flex: 1 1 auto;
   overflow: auto;
+
+  // Pure-CSS scroll shadow (https://lea.verou.me/blog/2012/04/background-attachment-local/):
+  // a background image that scrolls with the content covers the shadow
+  // except right at the edge of the scrollable area, so the bottom shadow
+  // (and matching top shadow) is only visible when there is more content to
+  // reveal by scrolling. This avoids the summary's final line looking like
+  // it was cut off mid-character at the `.card-content` scroll boundary —
+  // the fade now makes it visually obvious that more content can be
+  // scrolled into view.
+  background:
+    linear-gradient(var(--mat-sys-surface-container-low) 30%, transparent) local,
+    linear-gradient(transparent, var(--mat-sys-surface-container-low) 70%) local,
+    radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.18), transparent) scroll,
+    radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.18), transparent) scroll;
+  background-repeat: no-repeat;
+  background-size: 100% 24px, 100% 24px, 100% 8px, 100% 8px;
+  background-position: top, bottom, top, bottom;
 }
 
 .divider {

--- a/src/app/pages/dashboard-page/articles-card/articles-card.component.scss
+++ b/src/app/pages/dashboard-page/articles-card/articles-card.component.scss
@@ -21,6 +21,21 @@
     text-overflow: clip;
     margin-bottom: 0;
   }
+
+  // `.mdc-list-item` (this element itself) and its inner
+  // `.mdc-list-item__content` wrapper both set `overflow: hidden`, which MDC
+  // relies on for single-line truncation. With wrapped (multi-line) text
+  // inside an `overflow: hidden` ancestor, Chromium clips a hairline sliver
+  // off the inline-start edge of the first glyph on each wrapped line,
+  // making the leading character of every title and summary line look cut
+  // off (e.g. "encodeURI" rendering as "ıcodeURI"). Since this item's
+  // content always wraps now, the clipping is no longer needed: set both to
+  // `visible` so glyphs are no longer clipped.
+  overflow: visible;
+
+  ::ng-deep .mdc-list-item__content {
+    overflow: visible;
+  }
 }
 
 .summary {

--- a/src/app/pages/dashboard-page/articles-card/articles-card.component.scss
+++ b/src/app/pages/dashboard-page/articles-card/articles-card.component.scss
@@ -6,6 +6,21 @@
   height: auto;
   padding-top: 8px;
   padding-bottom: 8px;
+
+  // The MDC two-line list-item assumes a single-line title + single-line
+  // subtitle, so it applies `white-space: nowrap` + `text-overflow: ellipsis`
+  // and a negative bottom margin to the title to compensate for the
+  // subtitle's reserved line height. Our title can wrap to two lines, which
+  // breaks that assumption: the negative margin then pulls the title's
+  // second line up into the summary's first line, making the leading
+  // character of each look clipped/overlapped. Override both rules so the
+  // title wraps normally and the summary is pushed down to start after it.
+  ::ng-deep .mdc-list-item__primary-text {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    margin-bottom: 0;
+  }
 }
 
 .summary {


### PR DESCRIPTION
## Summary

Closes #188

- **タイトル先頭文字の重なり**: `mat-list-item` の2行レイアウト用CSS（MDC）はタイトル1行＋サブタイトル1行を前提に、タイトルへ `white-space: nowrap` / `text-overflow: ellipsis` と負の `margin-bottom` を適用する。記事タイトルは長さに応じて2行に折り返すため、その負marginがタイトル2行目をsummaryの1行目に重ねていた。`ArticlesCardComponent` のSCSSでタイトルの `white-space` / `overflow` / `margin-bottom` を上書きし、折り返しを正しく扱うようにした。
- **本文最終行の見切れ**: `dashboard-page-template.component.scss` の `.card-content { overflow: auto }` がカードの既定高さを超えると、summary最終行がスクロール境界で中途半端に見切れて見えていた。スクロール方向の端にCSSのみによるフェードシャドウ（[background-attachment: local の手法](https://lea.verou.me/blog/2012/04/background-attachment-local/)）を追加し、まだ続きがある場合のみ視覚的にスクロール可能であることを示すようにした。カードの高さ自体は変更せず、見た目の改善で対応している。

この `.card-content` はダッシュボードの他のカード（メニュー／更新履歴など）にも共通で使われているため、同様の見切れ改善が他カードにも適用される。

## 確認方法

S3の実記事データ（5記事）を同期し、`prebuild:articles` 経由で生成したデータを使ってローカル確認した。

```bash
aws s3 sync "s3://morihara-tech-articles/ng-devtools/" ./content/articles/ --profile morihara-prod
node scripts/prebuild-articles.mjs
yarn start
```

修正前はタイトル2行目とsummary1行目が重なって行頭文字が欠けて見えたが、修正後は重なりが解消されている。`content/articles/` と `src/generated/articles/*.json` はローカル確認用のため、本PRにはコンポーネントのCSS修正のみを含めている。

## Test plan

- [x] `yarn test` — 既存ユニットテスト33ファイル/42テストすべて通過（`articles-card.component.spec.ts` / `dashboard-page-template.component.spec.ts` を含む）
- [x] S3実データ（5記事）で `yarn start` し、ダッシュボードの「お役立ち記事」カードを目視確認
  - タイトルが2行に折り返ってもsummaryと重ならないことを確認
  - スクロール時、本文最終行が中途半端に見切れず、フェードでスクロール可能であることが分かることを確認
- [ ] レビュアーによる実機目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)