### PR TITLE
refs #197 本番URL(BASE_URL)の設定源を単一化

### DIFF
--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -125,8 +125,18 @@ if (!clientIdMatch) {
 }
 
 // 5. Inject canonical and hreflang <link> tags into every index.html under every locale dir.
+//    BASE_URL is read from environment.ts so it stays the single source of truth shared
+//    with src/app/core/services/structured-data.service.ts (Angular side). It can be
+//    overridden per-environment (e.g. staging/preview) via the BASE_URL env var, which
+//    takes precedence when set — useful for future GitHub Actions injection without
+//    touching environment.ts.
 
-const BASE_URL = 'https://devtools.morihara.tech';
+const baseUrlMatch = envSource.match(/baseUrl:\s*'([^']+)'/);
+if (!baseUrlMatch) {
+  console.error('site.baseUrl not found in environment.ts — cannot generate canonical/hreflang/sitemap URLs.');
+  process.exit(1);
+}
+const BASE_URL = process.env.BASE_URL || baseUrlMatch[1];
 
 /**
  * Removes a single trailing slash from a path, except for the root path "/"

--- a/src/app/core/services/structured-data.service.ts
+++ b/src/app/core/services/structured-data.service.ts
@@ -1,8 +1,13 @@
 import { DOCUMENT } from '@angular/common';
 import { Injectable, LOCALE_ID, inject } from '@angular/core';
+import { environment } from '../../../environments/environment';
 
-/** Canonical origin used for all indexable URLs (kept in sync with scripts/postbuild.mjs). */
-const BASE_URL = 'https://devtools.morihara.tech';
+/**
+ * Canonical origin used for all indexable URLs. Sourced from `environment.site.baseUrl`,
+ * which is also read directly by `scripts/postbuild.mjs` (BASE_URL) — the single source
+ * of truth for canonical/hreflang/sitemap/structured-data URLs.
+ */
+const BASE_URL = environment.site.baseUrl;
 
 /** Input required to build a `SoftwareApplication` JSON-LD entry for a tool page. */
 export interface SoftwareApplicationData {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -7,4 +7,12 @@ export const environment = {
     sidebarSlot: '9683601281',
     dashboardSlot: '2401831464',
   },
+  site: {
+    // Canonical origin used for all indexable URLs (canonical/hreflang/sitemap/
+    // structured data). This is the single source of truth: scripts/postbuild.mjs
+    // reads this same value out of this file (see BASE_URL there), so Angular
+    // (browser build) and the Node postbuild step never drift apart. Can be
+    // overridden per-environment via the BASE_URL env var in CI (see postbuild.mjs).
+    baseUrl: 'https://devtools.morihara.tech',
+  },
 };


### PR DESCRIPTION
## Summary
- Issue #197対応。`scripts/postbuild.mjs`と`src/app/core/services/structured-data.service.ts`にそれぞれ独立してハードコードされていた本番URL（`https://devtools.morihara.tech`）を`src/environments/environment.ts`の`site.baseUrl`に一本化した。
- `postbuild.mjs`はAdSense clientIdと同じ既存パターン（environment.tsをテキスト読み込みして正規表現抽出）でbaseUrlを取得するよう変更。将来ステージング/プレビュー環境向けに`BASE_URL`環境変数での上書きにも対応済み（今回はCI側の注入は未実装、設計上拡張しやすい形にとどめた）。
- `structured-data.service.ts`は`environment`を直接importして`environment.site.baseUrl`を参照するよう変更。
- インシデントレポート（`docs/core/tech/incident-report-indexing.md`）で指摘された「canonical/hreflang/sitemapのURLシグナル不整合」の再発防止の一環。

## Test plan
- [x] `yarn build`（ja/en両ロケール）が成功することを確認
- [x] 生成物を確認し、canonicalタグ・sitemap.xml・JSON-LD(`SoftwareApplication`)の`url`がすべて`https://devtools.morihara.tech/ja/json-formatter`で一致していることを確認
- [x] `yarn ng extract-i18n`は新規文言追加なしのため未実施（UI変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)