### PR TITLE
refs #193 deployment.ymlのcheckoutにfetch-depth: 0を追加

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -19,6 +19,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: 'Use Node.js ${{ env.NODE_VERSION }}'
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- Issue #193「sitemap.xmlのlastmodを実更新日ベースに修正する」の設計書（`docs/products/sitemap-lastmod/architecture.md` 論点4・フェーズ0）で明記された前提条件対応。
- `.github/workflows/deployment.yml` の `actions/checkout@v4` に `fetch-depth: 0`（全履歴取得）を追加し、CI上のshallow clone（デフォルト`fetch-depth: 1`）により `git log -1 --format=%ai -- <path>` が実質「ビルドコミット日時」に潰れる問題を解消する。
- `pr.yml`・`sandbox-deploy.yml` への同様の変更は設計書で明示的にスコープ外とされているため対応していない。

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deployment.yml'))"` でYAML構文を確認
- [x] 既存の他ステップ（setup-node, configure-aws-credentials等）の`with:`設定に影響がないことを目視確認
- [ ] マージ後、実際のCI実行でfetch-depth: 0によるチェックアウトとビルド成功を確認