### PR TITLE
refs #194 canonical/sitemap/サーバー応答のURL整合性をCIで自動検証する

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -45,3 +45,5 @@ jobs:
         run: aws s3 sync dist/${{ env.PROJECT_NAME }}/browser s3://${{ secrets.S3_BUCKET_NAME }} --delete
       - name: CloudFront Invalidation
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+      - name: Verify production URLs
+        run: node scripts/verify-production-urls.mjs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,8 +39,29 @@ jobs:
             exit 1
           fi
 
+  verify-url-consistency:
+    if: "! github.event.pull_request.draft"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+      - name: Build
+        run: yarn build
+      - name: Verify URL consistency (canonical/hreflang/internal links/sitemap)
+        run: node scripts/verify-url-consistency.mjs
+      - name: Run URL-consistency contract tests
+        run: node --test tests/url-consistency/
+
   auto-approve:
-    needs: check-i18n
+    needs: [check-i18n, verify-url-consistency]
     if: "! github.event.pull_request.draft"
     runs-on: ubuntu-latest
     permissions:

--- a/scripts/url-policy.mjs
+++ b/scripts/url-policy.mjs
@@ -1,0 +1,89 @@
+/**
+ * Single source of truth for the CloudFront Function redirect rules that sit
+ * in front of this site (see morihara-tech/build-tools#58 / build-tools#59,
+ * aws/devtools/devtools-frontsite.cf.yml). The Function itself lives in a
+ * separate repository and is NOT importable from here, so this module
+ * mirrors its two redirect rules with regexes so that Layer A
+ * (scripts/verify-url-consistency.mjs), Layer B
+ * (tests/url-consistency/mock-cloudfront-function.mjs) and Layer C
+ * (scripts/verify-production-urls.mjs) can all reason about "will this path
+ * 301?" without re-implementing the policy three times.
+ *
+ * Keep this file in sync with build-tools#59 whenever the CloudFront
+ * Function's redirect rules change. If the two ever drift, this repo's CI
+ * will pass while production 301s in ways this repo doesn't expect (or vice
+ * versa) — so treat a change to that Function as a signal to update this
+ * file too.
+ *
+ * Rules mirrored (see build-tools#59 for the canonical implementation):
+ *   1. uri === '/' (root, i.e. an empty/`/`-only path) → 301 to `/ja`.
+ *   2. Any path under a locale prefix (`/ja` or `/en`, at any depth, e.g.
+ *      `/ja/json-formatter`) that has a trailing slash → 301 to the same
+ *      path with the trailing slash stripped.
+ */
+
+const LOCALE_PREFIX_PATTERN = /^\/(ja|en)(\/|$)/;
+
+/**
+ * Normalizes a URL or path-like string down to just its path component
+ * (no origin, no query string, no hash), so callers can pass either a full
+ * URL (e.g. "https://devtools.morihara.tech/ja/") or a bare path (e.g.
+ * "/ja/").
+ */
+function toPath(urlOrPath) {
+  let path = urlOrPath;
+  // Strip a scheme+host prefix if present, e.g. "https://example.com/ja" → "/ja".
+  const originMatch = path.match(/^[a-z]+:\/\/[^/]+(\/.*)?$/i);
+  if (originMatch) {
+    path = originMatch[1] ?? '/';
+  }
+  // Drop query string / hash.
+  path = path.split('?')[0].split('#')[0];
+  return path;
+}
+
+/**
+ * Rule 1: the CloudFront Function treats both `/` and the empty string as
+ * "root", redirecting to `/ja`.
+ */
+function isRootPath(path) {
+  return path === '/' || path === '';
+}
+
+/**
+ * Rule 2: any locale-prefixed path (`/ja`, `/en`, and any depth below them,
+ * e.g. `/ja/json-formatter/`) that carries a trailing slash gets redirected
+ * to the same path with the trailing slash removed. This intentionally
+ * covers `/ja/` and `/en/` themselves as well as deeper pages.
+ */
+function isLocalePathWithTrailingSlash(path) {
+  return LOCALE_PREFIX_PATTERN.test(path) && path.length > 1 && path.endsWith('/');
+}
+
+/**
+ * Returns true if the given URL or path would be 301-redirected by the
+ * CloudFront Function.
+ */
+export function willRedirect(urlOrPath) {
+  const path = toPath(urlOrPath);
+  return isRootPath(path) || isLocalePathWithTrailingSlash(path);
+}
+
+/**
+ * Returns the path the CloudFront Function would redirect `urlOrPath` to,
+ * or `null` if `urlOrPath` would not be redirected (i.e. `willRedirect` is
+ * false for it).
+ */
+export function redirectTargetPath(urlOrPath) {
+  const path = toPath(urlOrPath);
+
+  if (isRootPath(path)) {
+    return '/ja';
+  }
+
+  if (isLocalePathWithTrailingSlash(path)) {
+    return path.slice(0, -1);
+  }
+
+  return null;
+}

--- a/scripts/verify-production-urls.mjs
+++ b/scripts/verify-production-urls.mjs
@@ -1,0 +1,178 @@
+/**
+ * Layer C of the URL-consistency verification (see Issue #194 /
+ * docs/core/tech/ci-url-consistency-verification.md).
+ *
+ * Runs against the built artifacts AFTER a real deployment (invoked as a
+ * post-CloudFront-Invalidation step in .github/workflows/deployment.yml).
+ * Collects every URL that Google/users are expected to be able to reach
+ * without a redirect hop — every sitemap.xml <loc> plus every page's
+ * canonical/hreflang (including x-default) URL — and performs a real HTTP
+ * request against each one with `redirect: 'manual'`, failing the build if
+ * anything other than 200 comes back (a 3xx here means production actually
+ * disagrees with what Layers A/B predicted, e.g. a CloudFront Function
+ * change that scripts/url-policy.mjs hasn't been updated to match).
+ *
+ * The status-checking logic (`checkUrls`) is exported so that
+ * tests/url-consistency/verify-url-consistency.contract.test.mjs (Layer B)
+ * can exercise the exact same logic against the mock CloudFront Function
+ * server instead of real production, keeping the "does this judge URLs
+ * correctly" logic covered by a fast, deterministic, always-on test.
+ *
+ * Node standard library only (fs, path, fetch — Node 18+). No added npm
+ * dependencies.
+ *
+ * Usage: node scripts/verify-production-urls.mjs
+ * Exit code: 0 if every URL returns 200, 1 otherwise (emits `::error::`
+ * GitHub Actions annotations). A failure here intentionally does NOT roll
+ * back the deployment (S3 sync / CloudFront invalidation have already
+ * happened by the time this step runs) — it only turns the workflow run
+ * red so a human notices and investigates.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+const BROWSER_DIR = 'dist/ng-devtools/browser';
+const LOCALES = ['ja', 'en'];
+
+/** Reads BASE_URL the same way scripts/postbuild.mjs does, from environment.ts. */
+export function resolveBaseUrl() {
+  const ENV_FILE = 'src/environments/environment.ts';
+  const envSource = readFileSync(ENV_FILE, 'utf-8');
+  const baseUrlMatch = envSource.match(/baseUrl:\s*'([^']+)'/);
+  if (!baseUrlMatch) {
+    throw new Error(`site.baseUrl not found in ${ENV_FILE}`);
+  }
+  return process.env.BASE_URL || baseUrlMatch[1];
+}
+
+/** Recursively collects every index.html under `dir`, excluding /error/ pages. */
+function findIndexHtmlFiles(dir) {
+  if (!existsSync(dir)) return [];
+  const allFiles = readdirSync(dir, { recursive: true, withFileTypes: false });
+  return /** @type {string[]} */ (allFiles)
+    .filter((f) => f === 'index.html' || f.endsWith('/index.html') || f.endsWith('\\index.html'))
+    .map((f) => join(dir, f))
+    .filter((f) => !f.replace(/\\/g, '/').includes('/error/'));
+}
+
+/**
+ * Collects the deduplicated set of URLs that must resolve with a plain 200:
+ * every sitemap.xml <loc>, plus every page's canonical and hreflang
+ * (including x-default) URLs.
+ */
+export function collectTargetUrls(browserDir = BROWSER_DIR) {
+  const urls = new Set();
+
+  const sitemapPath = join(browserDir, 'sitemap.xml');
+  if (existsSync(sitemapPath)) {
+    const sitemapXml = readFileSync(sitemapPath, 'utf-8');
+    for (const m of sitemapXml.matchAll(/<loc>([^<]+)<\/loc>/g)) {
+      urls.add(m[1]);
+    }
+  }
+
+  for (const locale of LOCALES) {
+    const localeDir = join(browserDir, locale);
+    for (const indexPath of findIndexHtmlFiles(localeDir)) {
+      const html = readFileSync(indexPath, 'utf-8');
+
+      for (const m of html.matchAll(/<link\s+rel="canonical"\s+href="([^"]+)"/g)) {
+        urls.add(m[1]);
+      }
+      for (const m of html.matchAll(/<link\s+rel="alternate"\s+hreflang="[^"]+"\s+href="([^"]+)"/g)) {
+        urls.add(m[1]);
+      }
+    }
+  }
+
+  return [...urls];
+}
+
+/**
+ * Requests every URL in `urls` with `redirect: 'manual'` and reports which
+ * ones did NOT come back 200. All URLs are checked before returning (no
+ * early return), so a single run reports every failure, not just the first.
+ *
+ * Retries are a defense against transient network blips when this runs in
+ * CI right after a fresh deploy (NOT a wait for CloudFront cache
+ * propagation — the invalidation step already ran before this script, so by
+ * the time we get here CloudFront should already be serving the new
+ * content; retries only exist to ride out an occasional flaky request).
+ *
+ * @param {string[]} urls
+ * @param {object} [options]
+ * @param {typeof fetch} [options.fetchImpl] - injectable for tests (Layer B
+ *   points this at the mock CloudFront Function server instead of the real
+ *   fetch/production).
+ * @param {number} [options.retries] - number of retry attempts per URL
+ *   after the first try (default 2, i.e. up to 3 attempts total).
+ * @param {number} [options.retryDelayMs] - delay between retries (default
+ *   10000ms / 10s).
+ * @returns {Promise<{url: string, status: number | null, error: string | null}[]>}
+ *   the subset of `urls` that did not resolve to 200 (empty if all passed).
+ */
+export async function checkUrls(urls, options = {}) {
+  const { fetchImpl = fetch, retries = 2, retryDelayMs = 10_000 } = options;
+
+  const failures = [];
+
+  for (const url of urls) {
+    let lastStatus = null;
+    let lastError = null;
+    let ok = false;
+
+    for (let attempt = 0; attempt <= retries && !ok; attempt++) {
+      if (attempt > 0) {
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+      }
+      try {
+        const response = await fetchImpl(url, { redirect: 'manual' });
+        lastStatus = response.status;
+        lastError = null;
+        if (response.status === 200) {
+          ok = true;
+        }
+      } catch (err) {
+        lastStatus = null;
+        lastError = err instanceof Error ? err.message : String(err);
+      }
+    }
+
+    if (!ok) {
+      failures.push({ url, status: lastStatus, error: lastError });
+    }
+  }
+
+  return failures;
+}
+
+async function main() {
+  const urls = collectTargetUrls();
+
+  if (urls.length === 0) {
+    console.error('::error::No URLs found to verify (sitemap.xml/canonical/hreflang missing) — did the build run?');
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Verifying ${urls.length} production URL(s) resolve to 200...`);
+  const failures = await checkUrls(urls);
+
+  if (failures.length > 0) {
+    for (const { url, status, error } of failures) {
+      const detail = error ? `request failed: ${error}` : `got HTTP ${status}`;
+      console.error(`::error::${url} — expected 200, ${detail}.`);
+    }
+    console.error(`\nFound ${failures.length} production URL inconsistency(ies) out of ${urls.length} checked.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`All ${urls.length} production URL(s) resolved to 200.`);
+}
+
+// Only run main() when executed directly (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/verify-url-consistency.mjs
+++ b/scripts/verify-url-consistency.mjs
@@ -1,0 +1,182 @@
+/**
+ * Layer A of the URL-consistency verification (see Issue #194 /
+ * docs/core/tech/ci-url-consistency-verification.md).
+ *
+ * Statically inspects the build output under dist/ng-devtools/browser and
+ * checks that every canonical URL, hreflang alternate URL, same-origin
+ * internal <a href> link, and sitemap.xml <loc> entry points at a URL that
+ * would NOT be 301-redirected by the production CloudFront Function (see
+ * scripts/url-policy.mjs for the mirrored redirect rules). If any of those
+ * URLs point at a path that redirects, Google (and users) would have to
+ * follow a redirect hop to reach the "real" page, which defeats the point of
+ * publishing a canonical/hreflang/sitemap URL in the first place.
+ *
+ * This script intentionally does NOT use a DOM parser — it follows the same
+ * regex-based extraction approach as scripts/postbuild.mjs (which generates
+ * the very tags this script verifies), so both scripts share a mental model
+ * of the HTML shape and only Node's standard library is required (no added
+ * npm dependencies).
+ *
+ * Usage: node scripts/verify-url-consistency.mjs
+ * Exit code: 0 if no inconsistency found, 1 otherwise (also emits
+ * `::error::` GitHub Actions annotations for each problem found).
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { willRedirect } from './url-policy.mjs';
+
+const BROWSER_DIR = 'dist/ng-devtools/browser';
+const LOCALES = ['ja', 'en'];
+
+/**
+ * Pre-existing, already-tracked internal-link findings that this script
+ * would otherwise fail the build on. These are real: they were discovered
+ * while building Layer A for the first time (see
+ * https://github.com/morihara-tech/ng-devtools/issues/204) and are caused
+ * by an Angular Router quirk — RouterLink to the root path ("/") serializes
+ * to the app's literal `<base href>` (e.g. "/ja/", trailing slash and all)
+ * rather than the trailing-slash-free canonical form ("/ja"). Fixing that
+ * requires an application-code (routing/template) change, which is outside
+ * this CI/CD task's scope.
+ *
+ * This allowlist intentionally applies ONLY to the internal-<a href> check
+ * (not to canonical/hreflang/sitemap, which are authored by postbuild.mjs
+ * and have no legitimate reason to ever appear here) so that:
+ *   - this one pre-existing, already-filed gap doesn't block unrelated PRs
+ *     the moment this CI job is turned on, while
+ *   - any NEW internal link pointing at a redirect-bound URL still fails
+ *     the build loudly.
+ *
+ * Remove an entry (and this comment can shrink accordingly) once the
+ * linked issue is fixed.
+ */
+const KNOWN_LEGACY_REDIRECT_INTERNAL_LINKS = new Set(['/ja/', '/en/']);
+
+/** Returns the path component of a URL (or path) — everything after the origin. */
+function toPath(urlOrPath) {
+  const originMatch = urlOrPath.match(/^[a-z]+:\/\/[^/]+(\/.*)?$/i);
+  return originMatch ? (originMatch[1] ?? '/') : urlOrPath;
+}
+
+/** Reads BASE_URL the same way scripts/postbuild.mjs does, from environment.ts. */
+function resolveBaseUrl() {
+  const ENV_FILE = 'src/environments/environment.ts';
+  const envSource = readFileSync(ENV_FILE, 'utf-8');
+  const baseUrlMatch = envSource.match(/baseUrl:\s*'([^']+)'/);
+  if (!baseUrlMatch) {
+    throw new Error(`site.baseUrl not found in ${ENV_FILE}`);
+  }
+  return process.env.BASE_URL || baseUrlMatch[1];
+}
+
+/** Recursively collects every index.html under `dir`, excluding /error/ pages. */
+function findIndexHtmlFiles(dir) {
+  if (!existsSync(dir)) return [];
+  const allFiles = readdirSync(dir, { recursive: true, withFileTypes: false });
+  return /** @type {string[]} */ (allFiles)
+    .filter((f) => f === 'index.html' || f.endsWith('/index.html') || f.endsWith('\\index.html'))
+    .map((f) => join(dir, f))
+    .filter((f) => !f.replace(/\\/g, '/').includes('/error/'));
+}
+
+/** Extracts all `href="..."` values for `<link rel="canonical">` tags. */
+function extractCanonicalUrls(html) {
+  const matches = [...html.matchAll(/<link\s+rel="canonical"\s+href="([^"]+)"/g)];
+  return matches.map((m) => m[1]);
+}
+
+/** Extracts all `href="..."` values for `<link rel="alternate" hreflang="...">` tags. */
+function extractHreflangUrls(html) {
+  const matches = [...html.matchAll(/<link\s+rel="alternate"\s+hreflang="([^"]+)"\s+href="([^"]+)"/g)];
+  return matches.map((m) => ({ hreflang: m[1], url: m[2] }));
+}
+
+/**
+ * Extracts same-origin internal <a href="..."> links, i.e. links that start
+ * with "/" (root-relative) or with BASE_URL. External links, mailto:,
+ * fragment-only links (#...), and asset links are ignored.
+ */
+function extractInternalLinks(html, baseUrl) {
+  const hrefs = [...html.matchAll(/<a\s+[^>]*href="([^"]+)"/g)].map((m) => m[1]);
+  const internal = [];
+  for (const href of hrefs) {
+    if (href.startsWith(baseUrl)) {
+      internal.push(href);
+    } else if (href.startsWith('/') && !href.startsWith('//')) {
+      internal.push(`${baseUrl}${href}`);
+    }
+  }
+  return internal;
+}
+
+/** Extracts every `<loc>...</loc>` entry from a sitemap.xml document. */
+function extractSitemapLocs(xml) {
+  return [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
+}
+
+function main() {
+  const baseUrl = resolveBaseUrl();
+  /** @type {string[]} */
+  const errors = [];
+
+  // --- Check every index.html's canonical / hreflang / internal links ---
+  for (const locale of LOCALES) {
+    const localeDir = join(BROWSER_DIR, locale);
+    for (const indexPath of findIndexHtmlFiles(localeDir)) {
+      const html = readFileSync(indexPath, 'utf-8');
+
+      for (const url of extractCanonicalUrls(html)) {
+        if (willRedirect(url)) {
+          errors.push(`${indexPath}: canonical URL "${url}" would be 301-redirected by CloudFront.`);
+        }
+      }
+
+      for (const { hreflang, url } of extractHreflangUrls(html)) {
+        if (willRedirect(url)) {
+          errors.push(`${indexPath}: hreflang="${hreflang}" URL "${url}" would be 301-redirected by CloudFront.`);
+        }
+      }
+
+      for (const url of extractInternalLinks(html, baseUrl)) {
+        if (!willRedirect(url)) continue;
+
+        if (KNOWN_LEGACY_REDIRECT_INTERNAL_LINKS.has(toPath(url))) {
+          console.warn(
+            `[known-issue #204] ${indexPath}: internal link "${url}" would be 301-redirected by CloudFront ` +
+              '(pre-existing, tracked — see https://github.com/morihara-tech/ng-devtools/issues/204).',
+          );
+          continue;
+        }
+
+        errors.push(`${indexPath}: internal link "${url}" would be 301-redirected by CloudFront.`);
+      }
+    }
+  }
+
+  // --- Check sitemap.xml ---
+  const sitemapPath = join(BROWSER_DIR, 'sitemap.xml');
+  if (!existsSync(sitemapPath)) {
+    errors.push(`${sitemapPath}: sitemap.xml not found — did the build run postbuild.mjs?`);
+  } else {
+    const sitemapXml = readFileSync(sitemapPath, 'utf-8');
+    for (const loc of extractSitemapLocs(sitemapXml)) {
+      if (willRedirect(loc)) {
+        errors.push(`${sitemapPath}: <loc>${loc}</loc> would be 301-redirected by CloudFront.`);
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    for (const error of errors) {
+      console.error(`::error::${error}`);
+    }
+    console.error(`\nFound ${errors.length} URL-consistency issue(s).`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log('URL consistency check passed: no canonical/hreflang/internal-link/sitemap URL would be redirected.');
+}
+
+main();

--- a/tests/url-consistency/mock-cloudfront-function.mjs
+++ b/tests/url-consistency/mock-cloudfront-function.mjs
@@ -1,0 +1,55 @@
+/**
+ * Layer B helper for Issue #194's URL-consistency contract tests.
+ *
+ * A minimal HTTP server (Node's built-in `http` module only — no added npm
+ * dependencies) that mimics the production CloudFront Function's redirect
+ * behavior as mirrored in scripts/url-policy.mjs:
+ *   - If the requested path would be redirected (`willRedirect`), respond
+ *     301 with a `Location` header pointing at `redirectTargetPath`.
+ *   - Otherwise respond 200.
+ *
+ * This lets verify-url-consistency.contract.test.mjs exercise the same
+ * request→outcome behavior a real CloudFront distribution would produce,
+ * without needing network access or a real deployment, so the contract
+ * between "what scripts/url-policy.mjs believes" and "what a client would
+ * observe" stays covered by a fast, deterministic test.
+ */
+
+import { createServer } from 'node:http';
+import { redirectTargetPath, willRedirect } from '../../scripts/url-policy.mjs';
+
+/**
+ * Creates (but does not start) the mock CloudFront Function HTTP server.
+ * Call `.listen(0)` on the result to bind an ephemeral port for tests.
+ */
+export function createMockCloudFrontServer() {
+  return createServer((req, res) => {
+    const path = req.url ?? '/';
+
+    if (willRedirect(path)) {
+      const target = redirectTargetPath(path);
+      res.writeHead(301, { Location: target ?? '/' });
+      res.end();
+      return;
+    }
+
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('OK');
+  });
+}
+
+/**
+ * Starts the mock server on an ephemeral port and resolves with
+ * `{ server, baseUrl }` once listening. Caller is responsible for calling
+ * `server.close()` when done.
+ */
+export function startMockCloudFrontServer() {
+  return new Promise((resolve) => {
+    const server = createMockCloudFrontServer();
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address !== null ? address.port : address;
+      resolve({ server, baseUrl: `http://127.0.0.1:${port}` });
+    });
+  });
+}

--- a/tests/url-consistency/verify-url-consistency.contract.test.mjs
+++ b/tests/url-consistency/verify-url-consistency.contract.test.mjs
@@ -1,0 +1,114 @@
+/**
+ * Layer B contract tests for Issue #194's URL-consistency verification.
+ *
+ * Uses Node's built-in test runner (`node --test`) and `assert` only — no
+ * added npm dependencies. Run with:
+ *
+ *   node --test tests/url-consistency/
+ *
+ * What this proves:
+ *  - "Normal" case: the URL set this repo actually publishes (sitemap.xml
+ *    <loc> + every page's canonical/hreflang URLs — taken from a real
+ *    `dist/ng-devtools/browser` build when present, otherwise a small
+ *    representative sample) all resolve to 200 against a server that
+ *    behaves exactly like the production CloudFront Function
+ *    (tests/url-consistency/mock-cloudfront-function.mjs, itself driven by
+ *    scripts/url-policy.mjs).
+ *  - "Abnormal" case: if a canonical URL were accidentally emitted with a
+ *    trailing slash under a locale prefix (e.g. "/ja/json-formatter/"
+ *    instead of "/ja/json-formatter") — exactly the kind of regression this
+ *    whole feature exists to catch — the shared judgment logic
+ *    (`checkUrls` from scripts/verify-production-urls.mjs, also used by
+ *    Layer C in production) detects it and reports a failure. This test is
+ *    a standing guarantee that the detection logic still fires; if it ever
+ *    stops failing on a redirect-bound URL, that's a regression in the
+ *    verification tooling itself.
+ */
+
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { after, before, describe, test } from 'node:test';
+import { checkUrls, collectTargetUrls, resolveBaseUrl } from '../../scripts/verify-production-urls.mjs';
+import { startMockCloudFrontServer } from './mock-cloudfront-function.mjs';
+
+const DIST_DIR = 'dist/ng-devtools/browser';
+
+/** Rewrites a URL's origin from `fromBaseUrl` to `toBaseUrl`, keeping the path. */
+function rewriteOrigin(url, fromBaseUrl, toBaseUrl) {
+  if (!url.startsWith(fromBaseUrl)) {
+    throw new Error(`URL "${url}" does not start with expected origin "${fromBaseUrl}"`);
+  }
+  return toBaseUrl + url.slice(fromBaseUrl.length);
+}
+
+/**
+ * Returns the URL set to validate against the mock server: the real build
+ * output when available (so the test reflects what actually ships), or a
+ * small representative sample otherwise (e.g. when running this test
+ * without having built the app first).
+ */
+function getSourceUrls(realBaseUrl) {
+  if (existsSync(`${DIST_DIR}/sitemap.xml`)) {
+    return collectTargetUrls(DIST_DIR);
+  }
+
+  return [
+    `${realBaseUrl}/ja`,
+    `${realBaseUrl}/en`,
+    `${realBaseUrl}/ja/json-formatter`,
+    `${realBaseUrl}/en/json-formatter`,
+    `${realBaseUrl}/ja/menu`,
+    `${realBaseUrl}/en/menu`,
+  ];
+}
+
+describe('Layer B: contract test for the URL-consistency detection logic', () => {
+  /** @type {import('node:http').Server} */
+  let server;
+  /** @type {string} */
+  let mockBaseUrl;
+  /** @type {string} */
+  let realBaseUrl;
+  /** @type {string[]} */
+  let sourceUrls;
+
+  before(async () => {
+    ({ server, baseUrl: mockBaseUrl } = await startMockCloudFrontServer());
+    realBaseUrl = resolveBaseUrl();
+    sourceUrls = getSourceUrls(realBaseUrl);
+    assert.ok(sourceUrls.length > 0, 'expected at least one source URL to validate');
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  test('normal case: every published URL resolves to 200 against the mock CloudFront Function', async () => {
+    const urlsAgainstMock = sourceUrls.map((url) => rewriteOrigin(url, realBaseUrl, mockBaseUrl));
+
+    const failures = await checkUrls(urlsAgainstMock, { fetchImpl: fetch, retries: 0 });
+
+    assert.deepEqual(
+      failures,
+      [],
+      `expected all URLs to resolve 200, but got failures: ${JSON.stringify(failures, null, 2)}`,
+    );
+  });
+
+  test('abnormal case: a canonical URL rewritten with a trailing slash under a locale prefix is detected as a redirect', async () => {
+    // Take one real "/ja/..." or "/en/..." URL and corrupt it into the exact
+    // shape the CloudFront Function 301s away from (trailing slash under a
+    // locale prefix) — simulating a regression where postbuild.mjs (or a
+    // future change) starts emitting trailing-slash URLs again.
+    const localeUrl = sourceUrls.find((url) => /\/(ja|en)(\/|$)/.test(url.slice(realBaseUrl.length)));
+    assert.ok(localeUrl, 'expected at least one locale-prefixed source URL to corrupt for this test');
+
+    const corruptedUrl = localeUrl.endsWith('/') ? localeUrl : `${localeUrl}/`;
+    const urlsAgainstMock = [rewriteOrigin(corruptedUrl, realBaseUrl, mockBaseUrl)];
+
+    const failures = await checkUrls(urlsAgainstMock, { fetchImpl: fetch, retries: 0 });
+
+    assert.equal(failures.length, 1, 'expected the corrupted trailing-slash URL to be detected as a failure');
+    assert.equal(failures[0].status, 301, 'expected the mock CloudFront Function to respond 301 for the corrupted URL');
+  });
+});


### PR DESCRIPTION
## 概要

Issue #194 の実装です。アーキテクチャ設計書 (docs/core/tech/ci-url-consistency-verification.md, PR #203, ブランチ docs/194-url-consistency-ci-verification-architecture) はまだ origin/master 未マージのため、設計内容の要約をEMから受け取り、それに厳密に従って実装しました。

3層構成:

- **Layer A** (`scripts/verify-url-consistency.mjs`, `.github/workflows/pr.yml` に新規ジョブ `verify-url-consistency`): ビルド成果物 (`dist/ng-devtools/browser`) 配下の全 `index.html`(`/error/` 除く)から canonical / hreflang(自ロケール・対ロケール・x-default) / 同一オリジンの内部 `<a href>` を正規表現ベースで抽出し(DOMパーサ不使用、`postbuild.mjs` と同じ手法)、`sitemap.xml` の `<loc>` と合わせて、本番 CloudFront Function が301リダイレクトするパスを指していないか検証します。
- **共通定義** (`scripts/url-policy.mjs`): CloudFront Function (`build-tools#58` / PR #59、`aws/devtools/devtools-frontsite.cf.yml`) の実際の301リダイレクトルール(① `/` → `/ja`、②ロケール配下の末尾スラッシュ付きパス → 末尾スラッシュ除去後のURL)を正規表現でミラーリングし、`willRedirect` / `redirectTargetPath` としてLayer A/B/Cから共通利用します。
- **Layer B** (`tests/url-consistency/`, `pr.yml` の同ジョブで実行): `mock-cloudfront-function.mjs` がNode標準の`http`モジュールのみで本番CloudFront Functionのリダイレクト挙動を再現するモックサーバーを実装。`verify-url-consistency.contract.test.mjs` が `node --test` で、正常系(実際のビルド成果物のURL集合が全て200)と異常系(canonicalを意図的に末尾スラッシュ付きに改変すると不整合を検知して失敗)の両方を常設テスト化しています。
- **Layer C** (`scripts/verify-production-urls.mjs`, `deployment.yml` の `CloudFront Invalidation` ステップ後に新規追加): デプロイ後、sitemap.xml + canonical/hreflang(x-default含む)の全URLに対し実際に `fetch(url, { redirect: 'manual' })` を行い、200以外を検知して `::error::` + exit code 1 で失敗させます(一過性のネットワーク揺らぎ対策の数回リトライあり、S3同期・CloudFront invalidationのロールバックは行いません)。判定ロジック(`checkUrls`)はexportされ、Layer Bの契約テストからも同じロジックが呼ばれる形にして重複実装を避けています。

追加npm依存はありません(Node標準API・`node --test`のみ使用)。

## 実装中に判明した既知の問題（重要・判断内容の共有）

`yarn build` した現状のビルド成果物に対しLayer Aを素の実装で実行したところ、以下の**実際のURL不整合**を検出しました:

- ヘッダーのロゴリンク(`src/app/components/header/header.component.html`)とサイトマップ用アクセシビリティnav(`src/app/components/sitemap/sitemap.component.html`)の `routerLink="/"` が、Angular Routerの`<base href="/ja/">`直下でのシリアライズにより `/ja/` `/en/` (末尾スラッシュ付き)を`href`として出力しており、これがCloudFront Functionの301リダイレクト対象パスに一致します(canonical URLは末尾スラッシュなしの`/ja`)。

これは本CI/CDタスクのスコープであるscripts/tests実装ではなく、アプリケーションコード(テンプレート/ルーティング)側の問題であるため、本PRでは修正していません。**判断**: この既知の問題を別Issue化し(#204)、`verify-url-consistency.mjs` 内に理由・参照先を明記した限定的な許容リスト(`KNOWN_LEGACY_REDIRECT_INTERNAL_LINKS`、内部リンクのチェックにのみ適用。canonical/hreflang/sitemapには一切適用しない)を設け、警告ログとして出力しつつビルドを失敗させないようにしました。これにより「完了条件1: 現状のビルド成果物に対して実行し成功(exit code 0)する」を満たしつつ、今後の**新規**の同種不整合はCIが引き続き検知します。Issue #204がクローズされ次第、許容リストからエントリを削除してください。

## 手元検証結果

- `yarn build` → `node scripts/verify-url-consistency.mjs`: **exit code 0**(既知issue #204分は警告ログのみ、それ以外の不整合なし)
- `node --test tests/url-consistency/`(Node 20.19.5で確認 — ローカル環境のNode 24.15.0では `--test <directory>` 引数自体が動作しない既知の挙動差異があったため、CIと同じ Node 20.19.5 バイナリを別途取得して確認しました):
  ```
  ✔ Layer B: contract test for the URL-consistency detection logic
    ✔ normal case: every published URL resolves to 200 against the mock CloudFront Function
    ✔ abnormal case: a canonical URL rewritten with a trailing slash under a locale prefix is detected as a redirect
  tests 2, pass 2, fail 0
  ```
  異常系テストは、canonical相当のURLを意図的に末尾スラッシュ付き(リダイレクト対象)に改変すると `checkUrls` が301を検知して失敗を報告することを確認しており、この検知ロジックが機能し続けることを継続的に担保する常設テストです。

## ワークフロー変更

- `.github/workflows/pr.yml`: 新規ジョブ `verify-url-consistency` を追加(`actions/checkout` → `actions/setup-node`(Node 20.19.5, `cache: yarn`) → `yarn --frozen-lockfile` → `yarn build` → Layer A → Layer B)。`auto-approve` の `needs` に追加。既存 `check-i18n` は変更なし。
- `.github/workflows/deployment.yml`: `CloudFront Invalidation` ステップの後に `Verify production URLs` ステップ(`node scripts/verify-production-urls.mjs`)を追加。失敗時もS3同期/invalidationのロールバックは行わない仕様(意図的)。

## スコープ外

- ブランチ保護のrequired check登録はGitHub上の手動設定のためスコープ外(未実施)。
- Issue #204(内部リンクの末尾スラッシュ問題の恒久修正)はアプリケーションコード側の対応が必要なため本PRのスコープ外。

## Test plan

- [x] `yarn build` の成果物に対し `node scripts/verify-url-consistency.mjs` が exit code 0 で成功することを確認
- [x] `node --test tests/url-consistency/` (Node 20.19.5) で正常系・異常系ともにpassすることを確認
- [x] `.github/workflows/pr.yml` / `.github/workflows/deployment.yml` のYAML構文を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)