### PR TITLE
refs #204 ロゴ/サイトマップ/サイドメニューのホームリンクの末尾スラッシュ問題を修正

### DIFF
--- a/scripts/verify-url-consistency.mjs
+++ b/scripts/verify-url-consistency.mjs
@@ -29,36 +29,6 @@ import { willRedirect } from './url-policy.mjs';
 const BROWSER_DIR = 'dist/ng-devtools/browser';
 const LOCALES = ['ja', 'en'];
 
-/**
- * Pre-existing, already-tracked internal-link findings that this script
- * would otherwise fail the build on. These are real: they were discovered
- * while building Layer A for the first time (see
- * https://github.com/morihara-tech/ng-devtools/issues/204) and are caused
- * by an Angular Router quirk — RouterLink to the root path ("/") serializes
- * to the app's literal `<base href>` (e.g. "/ja/", trailing slash and all)
- * rather than the trailing-slash-free canonical form ("/ja"). Fixing that
- * requires an application-code (routing/template) change, which is outside
- * this CI/CD task's scope.
- *
- * This allowlist intentionally applies ONLY to the internal-<a href> check
- * (not to canonical/hreflang/sitemap, which are authored by postbuild.mjs
- * and have no legitimate reason to ever appear here) so that:
- *   - this one pre-existing, already-filed gap doesn't block unrelated PRs
- *     the moment this CI job is turned on, while
- *   - any NEW internal link pointing at a redirect-bound URL still fails
- *     the build loudly.
- *
- * Remove an entry (and this comment can shrink accordingly) once the
- * linked issue is fixed.
- */
-const KNOWN_LEGACY_REDIRECT_INTERNAL_LINKS = new Set(['/ja/', '/en/']);
-
-/** Returns the path component of a URL (or path) — everything after the origin. */
-function toPath(urlOrPath) {
-  const originMatch = urlOrPath.match(/^[a-z]+:\/\/[^/]+(\/.*)?$/i);
-  return originMatch ? (originMatch[1] ?? '/') : urlOrPath;
-}
-
 /** Reads BASE_URL the same way scripts/postbuild.mjs does, from environment.ts. */
 function resolveBaseUrl() {
   const ENV_FILE = 'src/environments/environment.ts';
@@ -139,17 +109,9 @@ function main() {
       }
 
       for (const url of extractInternalLinks(html, baseUrl)) {
-        if (!willRedirect(url)) continue;
-
-        if (KNOWN_LEGACY_REDIRECT_INTERNAL_LINKS.has(toPath(url))) {
-          console.warn(
-            `[known-issue #204] ${indexPath}: internal link "${url}" would be 301-redirected by CloudFront ` +
-              '(pre-existing, tracked — see https://github.com/morihara-tech/ng-devtools/issues/204).',
-          );
-          continue;
+        if (willRedirect(url)) {
+          errors.push(`${indexPath}: internal link "${url}" would be 301-redirected by CloudFront.`);
         }
-
-        errors.push(`${indexPath}: internal link "${url}" would be 301-redirected by CloudFront.`);
       }
     }
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -46,7 +46,7 @@ export class AppComponent {
 
   headerModel: HeaderModel = {
     defaultTitle: $localize`:@@app.title:devTools`,
-    logo: { logoUrl: 'logo.svg', routerLink: '/' },
+    logo: { logoUrl: 'logo.svg' },
     appsButton: {
       routerLink: '/menu',
       label: $localize`:@@header.appsButton.label:メニュー`,

--- a/src/app/components/header/header-model.ts
+++ b/src/app/components/header/header-model.ts
@@ -7,7 +7,6 @@ export interface HeaderModel {
 
 export interface HeaderLogoModel {
   logoUrl: string;
-  routerLink: string;
 }
 
 export interface HeaderAppsButtonModel {

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -4,7 +4,7 @@
       <mat-icon>menu</mat-icon>
     </button>
     <div class="separator"></div>
-    <a [routerLink]="m.logo.routerLink" class="content">
+    <a appHomeLink class="content">
       <img class="logo" [src]="m.logo.logoUrl">
     </a>
     @if (m.appsButton) {

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -8,6 +8,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { LanguageButtonComponent } from './language-button/language-button.component';
 import { filter, map, mergeMap, startWith } from 'rxjs';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { HomeLinkDirective } from '../locale/home-link.directive';
 
 @Component({
     selector: 'app-header',
@@ -15,6 +16,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
         PersonButtonComponent,
         LanguageButtonComponent,
         RouterModule,
+        HomeLinkDirective,
         MatButtonModule,
         MatIconModule,
         MatToolbarModule

--- a/src/app/components/locale/home-link.directive.ts
+++ b/src/app/components/locale/home-link.directive.ts
@@ -1,0 +1,50 @@
+import { Directive, HostBinding, HostListener, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { PlatformService } from '../../core/services/platform.service';
+
+/**
+ * Renders a locale-aware, trailing-slash-free absolute `href` for links that
+ * navigate to the app root (e.g. "/ja", not "/ja/"), while still performing
+ * an in-app Router navigation (no full page reload) on click.
+ *
+ * Background: a plain `routerLink="/"` derives the anchor's `href` by
+ * resolving the root path against `<base href>` (e.g. "/ja/" — Angular's
+ * i18n build always emits a trailing slash on the locale base href). For the
+ * root path this serializes to the base href itself, "/ja/", instead of the
+ * canonical, trailing-slash-free form ("/ja") that matches the home page's
+ * canonical URL. Crawlers following that literal "/ja/" href take a needless
+ * 301 hop through the CloudFront redirect function.
+ *
+ * See https://github.com/morihara-tech/ng-devtools/issues/204.
+ *
+ * Usage: replace `routerLink="/"` (or `[routerLink]="'/'"`) with
+ * `appHomeLink` on the same anchor element.
+ */
+@Directive({
+  selector: '[appHomeLink]',
+  standalone: true,
+})
+export class HomeLinkDirective {
+  private readonly router = inject(Router);
+  private readonly platformService = inject(PlatformService);
+
+  @HostBinding('attr.href')
+  get href(): string {
+    const base = this.platformService.nativeDocument.querySelector('base')?.getAttribute('href') ?? '/';
+    const trimmed = base.replace(/\/+$/, '');
+    return trimmed || '/';
+  }
+
+  @HostListener('click', ['$event'])
+  onClick(event: MouseEvent): void {
+    if (!this.platformService.isBrowser()) return;
+    if (event.defaultPrevented) return;
+    // Let the browser handle non-primary-button clicks and modified clicks
+    // (open in new tab/window, etc.) natively instead of intercepting them.
+    if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      return;
+    }
+    event.preventDefault();
+    this.router.navigateByUrl('/');
+  }
+}

--- a/src/app/components/sidemenu/sidemenu.component.html
+++ b/src/app/components/sidemenu/sidemenu.component.html
@@ -13,7 +13,7 @@
 @if (topItem(); as top) {
   <mat-nav-list>
     <a mat-list-item class="item"
-      [routerLink]="top.routerLink"
+      appHomeLink
       (click)="clickMenu.emit()">
       @if (top.icon) {
         <mat-icon matListItemIcon>{{ top.icon }}</mat-icon>

--- a/src/app/components/sidemenu/sidemenu.component.ts
+++ b/src/app/components/sidemenu/sidemenu.component.ts
@@ -4,11 +4,13 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { RouterModule } from '@angular/router';
 import { SidemenuCategoryModel, SidemenuItemModel, SidemenuPersonModel } from './sidemenu-model';
+import { HomeLinkDirective } from '../locale/home-link.directive';
 
 @Component({
   selector: 'app-sidemenu',
   imports: [
     RouterModule,
+    HomeLinkDirective,
     MatExpansionModule,
     MatIconModule,
     MatListModule,
@@ -17,7 +19,11 @@ import { SidemenuCategoryModel, SidemenuItemModel, SidemenuPersonModel } from '.
   styleUrl: './sidemenu.component.scss',
 })
 export class SidemenuComponent {
-  /** Single top-level item rendered outside the accordion (e.g. Dashboard) */
+  /**
+   * Single top-level item rendered outside the accordion (e.g. Dashboard).
+   * Always links to the app root, so the template renders it with
+   * `appHomeLink` rather than `top.routerLink` (see HomeLinkDirective).
+   */
   readonly topItem = input<SidemenuItemModel>();
   /** Category groups rendered as an accordion */
   readonly categories = input<SidemenuCategoryModel[]>();

--- a/src/app/components/sitemap/sitemap.component.html
+++ b/src/app/components/sitemap/sitemap.component.html
@@ -1,7 +1,7 @@
 <nav class="cdk-visually-hidden">
   <h2 i18n="@@sitemap.heading">サイトマップ</h2>
   <ul>
-    <li><a routerLink="/" i18n="@@sitemap.link.home">ホーム</a></li>
+    <li><a appHomeLink i18n="@@sitemap.link.home">ホーム</a></li>
     <li><a routerLink="/guide" i18n="@@sitemap.link.guide">ご利用ガイド</a></li>
     <li><a routerLink="/articles" i18n="@@sitemap.link.articles">記事一覧</a></li>
     <li><a routerLink="/articles/uuid-v4-vs-v7" i18n="@@sitemap.link.articleUuidV4VsV7">UUID v4とv7の違いと使い分け</a></li>

--- a/src/app/components/sitemap/sitemap.component.ts
+++ b/src/app/components/sitemap/sitemap.component.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { HomeLinkDirective } from '../locale/home-link.directive';
 
 @Component({
   selector: 'app-sitemap',
-  imports: [RouterLink],
+  imports: [RouterLink, HomeLinkDirective],
   templateUrl: './sitemap.component.html',
 })
 export class SitemapComponent {}


### PR DESCRIPTION
## 背景

Issue #194 のCI実装（`scripts/verify-url-consistency.mjs`, PR #205）で発見された、ルート("/")へのRouterLinkが末尾スラッシュ付きパス（`/ja/`, `/en/`）としてhrefに出力される問題（Issue #204）を修正します。

`<base href="/ja/">` 配下で `routerLink="/"` を使うと、AngularのRouterLinkは `<base href>` の値をそのままhrefとしてシリアライズするため、末尾スラッシュ付きの `/ja/` が出力されます。一方、home pageのcanonical URLは末尾スラッシュなしの `/ja` であるため、これらの内部リンクをクローラーが辿るとCloudFront Functionにより301で `/ja` へリダイレクトされる無駄なホップが発生していました。

## 対応内容

- `src/app/components/locale/home-link.directive.ts` を新設。`[appHomeLink]` ディレクティブは
  - `<base href>` から末尾スラッシュを除いた絶対パス（`/ja`, `/en`）を `href` 属性として出力
  - クリック時は `Router.navigateByUrl('/')` でSPAナビゲーションを維持（`PlatformService.isBrowser()` でSSR/SSG安全性を担保、修飾クリックはブラウザのネイティブ挙動に委譲）
- 以下の3箇所の `routerLink="/"` を `appHomeLink` に置き換え:
  - `src/app/components/header/header.component.html`（ロゴリンク）。合わせて不要になった `HeaderLogoModel.routerLink` フィールドを削除
  - `src/app/components/sitemap/sitemap.component.html`（アクセシビリティ/クローラー向け隠しnavの「ホーム」リンク）
  - `src/app/components/sidemenu/sidemenu.component.html`（サイドメニューの `topItem`＝ダッシュボードリンク。常にルートを指すことをコメントで明記）
- `scripts/verify-url-consistency.mjs` から `KNOWN_LEGACY_REDIRECT_INTERNAL_LINKS` 許容リストおよび関連ヘルパー（`toPath`）を削除

## 許容リスト削除の根拠

`yarn build` でja/en両ロケールをビルドし、生成された `dist/ng-devtools/browser/{ja,en}/index.html` を直接確認した結果、修正前は `href="/ja/"` だった3箇所（ロゴ／サイトマップ隠しnav／サイドメニュー）が、修正後はいずれも `href="/ja"`（enは `/en`）となることを確認しました。

```
<a apphomelink href="/ja">                                  <!-- sitemap隠しnav -->
<a ... apphomelink class="content" href="/ja">               <!-- headerロゴ -->
<a ... mat-list-item apphomelink ... href="/ja" ...>          <!-- sidemenu topItem -->
```

`<base href="/ja/">` タグ自体（末尾スラッシュは仕様通り）を除き、`href="/ja/"` の出力は無くなっています。

また `node scripts/verify-url-consistency.mjs` を実行し、許容リストを削除した状態でも `[known-issue #204]` 警告・エラーともに発生せず正常終了することを確認済みです:

```
URL consistency check passed: no canonical/hreflang/internal-link/sitemap URL would be redirected.
```

## Test plan

- [x] `yarn build`（ja/en両ロケール）が成功すること
- [x] 生成された `index.html` 内の対象3リンクのhrefが `/ja` `/en`（末尾スラッシュなし）になっていること
- [x] `node scripts/verify-url-consistency.mjs` が警告・エラー無しで成功すること（legacy許容リスト削除後）
- [x] `yarn test` が全て成功すること（既存33ファイル/42テスト、無関係な事前からのMaterial iconコンソールエラーのみ）
- [x] UI上の見た目・レイアウトの変更が無いこと（href出力とクリック時ナビゲーションのみの変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)