### PR TITLE
全ページ共通のパンくずリストを導入し末尾をh1としてマークアップする

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,5 +6,6 @@
   (clickPersonContext)="onClickPersonContext($event)"
 ></app-header>
 <app-sidenav [(toggle)]="toggle" class="sidenav">
+  <app-breadcrumb></app-breadcrumb>
   <router-outlet></router-outlet>
 </app-sidenav>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,6 +10,7 @@ import { Meta, Title } from '@angular/platform-browser';
 import { SidenavComponent } from "./components/sidenav/sidenav.component";
 import { IconService } from './icon.service';
 import { SitemapComponent } from './components/sitemap/sitemap.component';
+import { BreadcrumbComponent } from './components/breadcrumb/breadcrumb.component';
 import { MENU_CATEGORIES, MENU_DASHBOARD } from '../resources/menu/def/menu-def';
 import { environment } from '../environments/environment';
 import { DOCUMENT } from '@angular/common';
@@ -28,6 +29,7 @@ type WindowWithGtag = Window & { gtag?: (...args: unknown[]) => void };
         MatBottomSheetModule,
         RouterOutlet,
         SitemapComponent,
+        BreadcrumbComponent,
     ],
     templateUrl: './app.component.html',
     styleUrl: './app.component.scss'

--- a/src/app/components/breadcrumb/breadcrumb.component.html
+++ b/src/app/components/breadcrumb/breadcrumb.component.html
@@ -1,0 +1,18 @@
+<nav [attr.aria-label]="navLabel" class="breadcrumb">
+  <ol>
+    @for (seg of segments(); track $index; let last = $last) {
+      <li>
+        @if (seg.isCurrent) {
+          <h1 class="breadcrumb-current">{{ seg.name }}</h1>
+        } @else if (seg.isHome) {
+          <a appHomeLink>{{ seg.name }}</a>
+        } @else if (seg.routerLink) {
+          <a [routerLink]="seg.routerLink">{{ seg.name }}</a>
+        } @else {
+          <span>{{ seg.name }}</span>
+        }
+        @if (!last) { <span class="separator" aria-hidden="true">&rsaquo;</span> }
+      </li>
+    }
+  </ol>
+</nav>

--- a/src/app/components/breadcrumb/breadcrumb.component.scss
+++ b/src/app/components/breadcrumb/breadcrumb.component.scss
@@ -1,0 +1,55 @@
+// Quiet, auxiliary trail — same register as app-header/app-sitemap, never
+// competing with the tool content below it. Sits full-width above the page
+// content, so its horizontal padding mirrors
+// ApplicationPageTemplateComponent's `.page-content-wrapper` gutters (8px on
+// mobile, 16px on desktop) even though many pages (dashboard/menu) don't use
+// that template.
+.breadcrumb {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
+}
+
+ol {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+li {
+  display: flex;
+  align-items: baseline;
+}
+
+a,
+span,
+.breadcrumb-current {
+  font-size: var(--mat-sys-label-small-size);
+  line-height: var(--mat-sys-label-small-line-height);
+  font-weight: var(--mat-sys-label-small-weight);
+  color: var(--mat-sys-on-surface-variant);
+}
+
+a {
+  text-decoration: none;
+
+  &:hover,
+  &:focus-visible {
+    text-decoration: underline;
+  }
+}
+
+.breadcrumb-current {
+  // Reset the browser's default large/bold <h1> styling: visually this is
+  // just the trail's last node, sized like its siblings.
+  margin: 0;
+  font-weight: 700;
+  color: var(--mat-sys-on-surface);
+}
+
+.separator {
+  margin: 0 4px;
+  color: var(--mat-sys-outline);
+}

--- a/src/app/components/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/components/breadcrumb/breadcrumb.component.spec.ts
@@ -1,0 +1,56 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { BreadcrumbComponent } from './breadcrumb.component';
+
+describe('BreadcrumbComponent', () => {
+  let fixture: ComponentFixture<BreadcrumbComponent>;
+  let harness: RouterTestingHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BreadcrumbComponent],
+      providers: [
+        provideRouter([
+          { path: '', data: { breadcrumb: { label: 'ダッシュボードのラベル' } }, children: [] },
+          { path: 'json-formatter', children: [] },
+          { path: 'guide', data: { breadcrumb: { label: 'ご利用ガイド' } }, children: [] },
+        ]),
+      ],
+    }).compileComponents();
+
+    harness = await RouterTestingHarness.create();
+  });
+
+  it('renders the dashboard as a single current h1 node', async () => {
+    fixture = TestBed.createComponent(BreadcrumbComponent);
+    await harness.navigateByUrl('/');
+    fixture.detectChanges();
+
+    const h1 = fixture.nativeElement.querySelector('h1.breadcrumb-current');
+    expect(h1?.textContent?.trim()).toBe('ダッシュボードのラベル');
+    expect(fixture.nativeElement.querySelectorAll('li').length).toBe(1);
+  });
+
+  it('renders Home > category > current for a menu-def tool page', async () => {
+    fixture = TestBed.createComponent(BreadcrumbComponent);
+    await harness.navigateByUrl('/json-formatter');
+    fixture.detectChanges();
+
+    const items = Array.from<HTMLElement>(fixture.nativeElement.querySelectorAll('li'));
+    expect(items.length).toBe(3);
+    const h1 = fixture.nativeElement.querySelector('h1.breadcrumb-current');
+    expect(h1).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('a[appHomeLink]')).toBeTruthy();
+  });
+
+  it('renders a route-data-driven page with a link back to Home', async () => {
+    fixture = TestBed.createComponent(BreadcrumbComponent);
+    await harness.navigateByUrl('/guide');
+    fixture.detectChanges();
+
+    const h1 = fixture.nativeElement.querySelector('h1.breadcrumb-current');
+    expect(h1?.textContent?.trim()).toBe('ご利用ガイド');
+    expect(fixture.nativeElement.querySelectorAll('li').length).toBe(2);
+  });
+});

--- a/src/app/components/breadcrumb/breadcrumb.component.ts
+++ b/src/app/components/breadcrumb/breadcrumb.component.ts
@@ -1,0 +1,60 @@
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, NavigationEnd, Router, RouterLink } from '@angular/router';
+import { filter, map, mergeMap } from 'rxjs';
+import { HomeLinkDirective } from '../locale/home-link.directive';
+import { BreadcrumbService } from '../../core/services/breadcrumb.service';
+import { StructuredDataService } from '../../core/services/structured-data.service';
+import { BreadcrumbSegment } from './breadcrumb.model';
+
+/**
+ * Site-wide breadcrumb trail, mounted once in `AppComponent` so every page
+ * (including `dashboard-page`/`menu-page`, which don't use
+ * `ApplicationPageTemplateComponent`) gets it automatically.
+ *
+ * The trail's last node doubles as the page's `<h1>` — see
+ * `docs/core/tech/incident-report-indexing.md` for why every page needs
+ * exactly one `<h1>` and why a breadcrumb, rather than a bare heading, was
+ * chosen to host it.
+ */
+@Component({
+  selector: 'app-breadcrumb',
+  imports: [RouterLink, HomeLinkDirective],
+  templateUrl: './breadcrumb.component.html',
+  styleUrl: './breadcrumb.component.scss',
+})
+export class BreadcrumbComponent {
+  private readonly router = inject(Router);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly breadcrumbService = inject(BreadcrumbService);
+  private readonly structuredDataService = inject(StructuredDataService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly navLabel = $localize`:@@breadcrumb.nav.label:パンくずリスト`;
+
+  protected readonly segments = signal<BreadcrumbSegment[]>([]);
+
+  constructor() {
+    this.router.events
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        map(() => this.activatedRoute),
+        map((route) => {
+          while (route.firstChild) {
+            route = route.firstChild;
+          }
+          return route;
+        }),
+        filter((route) => route.outlet === 'primary'),
+        mergeMap((route) => route.data),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe((data) => {
+        const url = this.router.url;
+        const path = url.split('?')[0].split('#')[0];
+        const resolved = this.breadcrumbService.resolve(path, data);
+        this.segments.set(resolved);
+        this.structuredDataService.setBreadcrumbList(resolved);
+      });
+  }
+}

--- a/src/app/components/breadcrumb/breadcrumb.model.ts
+++ b/src/app/components/breadcrumb/breadcrumb.model.ts
@@ -1,0 +1,30 @@
+/** A single node in the resolved breadcrumb trail, ready for rendering. */
+export interface BreadcrumbSegment {
+  /** Display label. */
+  name: string;
+  /** Router link, when this node is navigable. Category nodes have no link. */
+  routerLink?: string;
+  /** Whether this node is the Home node (rendered via `appHomeLink`). */
+  isHome: boolean;
+  /** Whether this node is the current page (rendered as `<h1>`, not a link). */
+  isCurrent: boolean;
+}
+
+/** A navigable ancestor node used when building a breadcrumb trail from route data. */
+export interface BreadcrumbLink {
+  /** Display label. */
+  label: string;
+  /** Router link for this ancestor. */
+  routerLink: string;
+}
+
+/**
+ * Route `data.breadcrumb` shape for pages not covered by `MENU_CATEGORIES`
+ * (dashboard, guide, privacy-policy, operator-info, menu, articles list/detail).
+ */
+export interface RouteBreadcrumb {
+  /** Current page label. Falls back to `route.data.title` when omitted (e.g. resolved article titles). */
+  label?: string;
+  /** Ancestor nodes inserted between Home and the current page. */
+  parents?: BreadcrumbLink[];
+}

--- a/src/app/core/services/breadcrumb.service.spec.ts
+++ b/src/app/core/services/breadcrumb.service.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed } from '@angular/core/testing';
+import { BreadcrumbService } from './breadcrumb.service';
+
+describe('BreadcrumbService', () => {
+  let service: BreadcrumbService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(BreadcrumbService);
+  });
+
+  it('should create', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('resolves the dashboard as a single, current Home node', () => {
+    const result = service.resolve('/', { breadcrumb: { label: 'テストダッシュボード' } });
+    expect(result).toEqual([
+      { name: 'テストダッシュボード', routerLink: '/', isHome: true, isCurrent: true },
+    ]);
+  });
+
+  it('falls back to the generic Home label when the dashboard has no breadcrumb data', () => {
+    const result = service.resolve('/', {});
+    expect(result.length).toBe(1);
+    expect(result[0].isCurrent).toBe(true);
+    expect(result[0].isHome).toBe(true);
+  });
+
+  it('resolves a menu-def tool page as Home > category > current', () => {
+    const result = service.resolve('/json-formatter', {});
+    expect(result.length).toBe(3);
+    expect(result[0]).toEqual({ name: 'ホーム', routerLink: '/', isHome: true, isCurrent: false });
+    expect(result[1].routerLink).toBeUndefined();
+    expect(result[1].isCurrent).toBe(false);
+    expect(result[2]).toEqual({ name: 'JSON整形', routerLink: '/json-formatter', isHome: false, isCurrent: true });
+  });
+
+  it('resolves a route-data-driven page (no parents) using breadcrumb.label', () => {
+    const result = service.resolve('/guide', { breadcrumb: { label: 'ご利用ガイド' } });
+    expect(result).toEqual([
+      { name: 'ホーム', routerLink: '/', isHome: true, isCurrent: false },
+      { name: 'ご利用ガイド', routerLink: '/guide', isHome: false, isCurrent: true },
+    ]);
+  });
+
+  it('resolves a route-data-driven page with parents (e.g. article detail)', () => {
+    const result = service.resolve('/articles/some-slug', {
+      title: '記事タイトル',
+      breadcrumb: { parents: [{ label: '記事一覧', routerLink: '/articles' }] },
+    });
+    expect(result).toEqual([
+      { name: 'ホーム', routerLink: '/', isHome: true, isCurrent: false },
+      { name: '記事一覧', routerLink: '/articles', isHome: false, isCurrent: false },
+      { name: '記事タイトル', routerLink: '/articles/some-slug', isHome: false, isCurrent: true },
+    ]);
+  });
+
+  it('falls back to an empty label when neither breadcrumb.label nor data.title is present', () => {
+    const result = service.resolve('/unknown-route', {});
+    expect(result[result.length - 1].name).toBe('');
+  });
+});

--- a/src/app/core/services/breadcrumb.service.ts
+++ b/src/app/core/services/breadcrumb.service.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@angular/core';
+import { Data } from '@angular/router';
+import { MENU_CATEGORIES } from '../../../resources/menu/def/menu-def';
+import { BreadcrumbSegment, RouteBreadcrumb } from '../../components/breadcrumb/breadcrumb.model';
+
+/** Home node label, shared by every trail (either as an ancestor link or, on the dashboard, as the current page). */
+const HOME_LABEL = $localize`:@@breadcrumb.home:ホーム`;
+
+/**
+ * Resolves the breadcrumb trail (and, implicitly, the `<h1>` page title) for
+ * the current leaf route.
+ *
+ * Three resolution strategies, tried in order:
+ * 1. The dashboard (`path === '/'`) — a single Home node, marked current.
+ * 2. Any route registered as a `MenuItem` under `MENU_CATEGORIES` — trail is
+ *    `Home > category > current page`, mirroring `AppComponent.setMetaDescription()`'s
+ *    existing `routerLink` lookup.
+ * 3. Everything else (guide/privacy-policy/operator-info/menu/articles) — resolved
+ *    from `route.data.breadcrumb` (see `RouteBreadcrumb`).
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class BreadcrumbService {
+  /** Builds the breadcrumb trail for the leaf route at `path`, given its resolved `data`. */
+  resolve(path: string, data: Data): BreadcrumbSegment[] {
+    const home: BreadcrumbSegment = { name: HOME_LABEL, routerLink: '/', isHome: true, isCurrent: false };
+
+    if (path === '/') {
+      const breadcrumb = data['breadcrumb'] as RouteBreadcrumb | undefined;
+      return [{ ...home, name: breadcrumb?.label ?? HOME_LABEL, isCurrent: true }];
+    }
+
+    const category = MENU_CATEGORIES.find((cat) => cat.items.some((item) => item.routerLink === path));
+    if (category) {
+      const item = category.items.find((it) => it.routerLink === path)!;
+      return [
+        home,
+        { name: category.label, routerLink: undefined, isHome: false, isCurrent: false },
+        { name: item.label, routerLink: path, isHome: false, isCurrent: true },
+      ];
+    }
+
+    const breadcrumb = data['breadcrumb'] as RouteBreadcrumb | undefined;
+    const parents: BreadcrumbSegment[] = (breadcrumb?.parents ?? []).map((parent) => ({
+      name: parent.label,
+      routerLink: parent.routerLink,
+      isHome: false,
+      isCurrent: false,
+    }));
+    const currentLabel = breadcrumb?.label ?? (data['title'] as string | undefined) ?? '';
+
+    return [
+      home,
+      ...parents,
+      { name: currentLabel, routerLink: path, isHome: false, isCurrent: true },
+    ];
+  }
+}

--- a/src/app/core/services/structured-data.service.spec.ts
+++ b/src/app/core/services/structured-data.service.spec.ts
@@ -1,0 +1,58 @@
+import { LOCALE_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { StructuredDataService } from './structured-data.service';
+
+describe('StructuredDataService', () => {
+  let service: StructuredDataService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: LOCALE_ID, useValue: 'ja' }],
+    });
+    service = TestBed.inject(StructuredDataService);
+    document.querySelectorAll('script[type="application/ld+json"]').forEach((el) => el.remove());
+  });
+
+  it('should create', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('does not emit a BreadcrumbList script for a single-node trail', () => {
+    service.setBreadcrumbList([{ name: 'ホーム', routerLink: '/' }]);
+    expect(document.querySelectorAll('script[type="application/ld+json"]').length).toBe(0);
+  });
+
+  it('emits a BreadcrumbList with only URL-bearing nodes, normalizing the home URL', () => {
+    service.setBreadcrumbList([
+      { name: 'ホーム', routerLink: '/' },
+      { name: 'フォーマッター', routerLink: undefined },
+      { name: 'JSON整形', routerLink: '/json-formatter' },
+    ]);
+    const scripts = document.querySelectorAll('script[type="application/ld+json"]');
+    expect(scripts.length).toBe(1);
+    const json = JSON.parse(scripts[0].textContent ?? '{}');
+    expect(json['@type']).toBe('BreadcrumbList');
+    expect(json.itemListElement).toEqual([
+      { '@type': 'ListItem', position: 1, name: 'ホーム', item: 'https://devtools.morihara.tech/ja' },
+      { '@type': 'ListItem', position: 2, name: 'JSON整形', item: 'https://devtools.morihara.tech/ja/json-formatter' },
+    ]);
+  });
+
+  it('replaces the previous BreadcrumbList script on repeated calls, without touching addSoftwareApplication', () => {
+    service.addSoftwareApplication({ name: 'x', description: 'y', routerLink: '/x' });
+    service.setBreadcrumbList([
+      { name: 'ホーム', routerLink: '/' },
+      { name: 'A', routerLink: '/a' },
+    ]);
+    service.setBreadcrumbList([
+      { name: 'ホーム', routerLink: '/' },
+      { name: 'B', routerLink: '/b' },
+    ]);
+    const scripts = Array.from(document.querySelectorAll('script[type="application/ld+json"]'));
+    expect(scripts.length).toBe(2);
+    const breadcrumbScript = scripts.find((s) => s.textContent?.includes('BreadcrumbList'));
+    expect(breadcrumbScript?.textContent).toContain('"name":"B"');
+    service.remove();
+    expect(document.querySelectorAll('script[type="application/ld+json"]').length).toBe(1);
+  });
+});

--- a/src/app/core/services/structured-data.service.ts
+++ b/src/app/core/services/structured-data.service.ts
@@ -33,6 +33,7 @@ export class StructuredDataService {
   private readonly locale = inject(LOCALE_ID);
 
   private script?: HTMLScriptElement;
+  private breadcrumbScript?: HTMLScriptElement;
 
   /**
    * Adds a `SoftwareApplication` JSON-LD script tag for a tool page.
@@ -62,5 +63,42 @@ export class StructuredDataService {
   remove(): void {
     this.script?.remove();
     this.script = undefined;
+  }
+
+  /**
+   * Injects/replaces a `BreadcrumbList` JSON-LD script tag for the current
+   * breadcrumb trail. Kept in a dedicated field so it never clobbers the
+   * per-tool-page `SoftwareApplication` script managed by `addSoftwareApplication`/`remove`.
+   *
+   * Nodes without a `routerLink` (breadcrumb category labels, which have no
+   * URL of their own) are omitted from `itemListElement` — every emitted
+   * `ListItem` must have a valid `item` URL. The single-node dashboard trail
+   * (Home only) is skipped entirely, since a one-item BreadcrumbList carries
+   * no information.
+   */
+  setBreadcrumbList(items: { name: string; routerLink?: string }[]): void {
+    this.breadcrumbScript?.remove();
+    this.breadcrumbScript = undefined;
+    if (items.length < 2) return;
+
+    const script = this.document.createElement('script');
+    script.type = 'application/ld+json';
+    script.text = JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: items
+        .filter((it) => it.routerLink)
+        .map((it, i) => ({
+          '@type': 'ListItem',
+          position: i + 1,
+          name: it.name,
+          // Home's routerLink is "/" — appended naively that would double up
+          // into a trailing slash ("/ja/"), the exact issue fixed for the
+          // home link elsewhere (see HomeLinkDirective / issue #204).
+          item: `${BASE_URL}/${this.locale}${it.routerLink === '/' ? '' : it.routerLink}`,
+        })),
+    });
+    this.document.head.appendChild(script);
+    this.breadcrumbScript = script;
   }
 }

--- a/src/app/pages/articles-page/articles-page.routes.ts
+++ b/src/app/pages/articles-page/articles-page.routes.ts
@@ -52,7 +52,12 @@ const articleRoutes: Routes = articlesListJa.map((article) => ({
     title: resolveArticleTitle(article.slug),
     description: resolveArticleDescription(article.slug),
   },
-  data: { slug: article.slug },
+  data: {
+    slug: article.slug,
+    // No `label` here: BreadcrumbService falls back to the resolved
+    // `title` above for the current-page node.
+    breadcrumb: { parents: [{ label: $localize`:@@breadcrumb.articles:記事一覧`, routerLink: '/articles' }] },
+  },
 }));
 
 export const articlesPageRoutes: Routes = [
@@ -62,6 +67,7 @@ export const articlesPageRoutes: Routes = [
     data: {
       title: $localize`:@@page.articles.title:記事一覧`,
       description: $localize`:@@page.articles.description:devTools が提供するツールに関連するトピックを掘り下げて解説する記事の一覧です。`,
+      breadcrumb: { label: $localize`:@@page.articles.title:記事一覧` },
     },
   },
   ...articleRoutes,

--- a/src/app/pages/dashboard-page/dashboard-page.routes.ts
+++ b/src/app/pages/dashboard-page/dashboard-page.routes.ts
@@ -5,6 +5,9 @@ export const dashboardPageRoutes: Routes = [
   {
     path: '',
     component: DashboardPageComponent,
-    data: { title: $localize`:@@page.dashboard.title:JSON整形・SQL整形・UUID生成など無料の開発者ツール` },
+    data: {
+      title: $localize`:@@page.dashboard.title:JSON整形・SQL整形・UUID生成など無料の開発者ツール`,
+      breadcrumb: { label: $localize`:@@page.dashboard.breadcrumb:無料で使える開発者ツール集` },
+    },
   },
 ];

--- a/src/app/pages/guide-page/guide-page.routes.ts
+++ b/src/app/pages/guide-page/guide-page.routes.ts
@@ -8,6 +8,7 @@ export const guidePageRoutes: Routes = [
     data: {
       title: $localize`:@@page.guide.title:ご利用ガイド`,
       description: $localize`:@@page.guide.description:devTools が提供する各ツールについて、どんな場面で使えるかを簡単に紹介します。詳しい使い方や仕様は各ツールのページをご覧ください。`,
+      breadcrumb: { label: $localize`:@@page.guide.title:ご利用ガイド` },
     },
   },
 ];

--- a/src/app/pages/menu-page/menu-page.routes.ts
+++ b/src/app/pages/menu-page/menu-page.routes.ts
@@ -8,6 +8,7 @@ export const menuPageRoutes: Routes = [
     data: {
       title: $localize`:@@page.menu.title:メニュー`,
       description: $localize`:@@page.menu.description:devTools で利用可能な全ツールの一覧です。`,
+      breadcrumb: { label: $localize`:@@page.menu.title:メニュー` },
     },
   },
 ];

--- a/src/app/pages/operator-info-page/operator-info-page.routes.ts
+++ b/src/app/pages/operator-info-page/operator-info-page.routes.ts
@@ -8,6 +8,7 @@ export const operatorInfoPageRoutes: Routes = [
     data: {
       title: $localize`:@@page.operatorInfo.title:運営者情報・お問い合わせ`,
       description: $localize`:@@page.operatorInfo.description:当サイトの運営者情報およびお問い合わせ方法についての説明です。`,
+      breadcrumb: { label: $localize`:@@page.operatorInfo.title:運営者情報・お問い合わせ` },
     },
   },
 ];

--- a/src/app/pages/privacy-policy-page/privacy-policy-page.routes.ts
+++ b/src/app/pages/privacy-policy-page/privacy-policy-page.routes.ts
@@ -8,6 +8,7 @@ export const privacyPolicyPageRoutes: Routes = [
     data: {
       title: $localize`:@@page.privacyPolicy.title:プライバシーポリシー`,
       description: $localize`:@@page.privacyPolicy.description:個人情報の取り扱いおよびGoogle Analyticsの利用についての説明です。`,
+      breadcrumb: { label: $localize`:@@page.privacyPolicy.title:プライバシーポリシー` },
     },
   },
 ];

--- a/src/resources/texts/def/messages.en.xlf
+++ b/src/resources/texts/def/messages.en.xlf
@@ -547,6 +547,12 @@
         <target>About the SVG Viewer</target>
       </segment>
     </unit>
+    <unit id="page.dashboard.breadcrumb">
+      <segment state="initial">
+        <source>無料で使える開発者ツール集</source>
+        <target>Free Dev Toolbox</target>
+      </segment>
+    </unit>
     <unit id="page.dashboard.card.ad.title">
       <segment state="initial">
         <source>広告</source>
@@ -1515,6 +1521,24 @@ When OFF, uses decodeURI to decode while preserving the URL structure.</target>
       <segment state="initial">
         <source> 当サイトでは、サービスの向上および最適なパーソナライズのためにCookieを使用しています。詳細は<pc id="0" equivStart="START_LINK" equivEnd="CLOSE_LINK" type="link" dispStart="&lt;a routerLink=&quot;/privacy-policy&quot; (click)=&quot;onPrivacyPolicy()&quot;&gt;" dispEnd="&lt;/a&gt;">プライバシーポリシー</pc>をご確認ください。 </source>
         <target> We use cookies to improve our service and provide personalized experiences. For more details, please review our <pc id="0" equivStart="START_LINK" equivEnd="CLOSE_LINK" type="link" dispStart="&lt;a routerLink=&quot;/privacy-policy&quot; (click)=&quot;onPrivacyPolicy()&quot;&gt;" dispEnd="&lt;/a&gt;">Privacy Policy</pc>. </target>
+      </segment>
+    </unit>
+    <unit id="breadcrumb.articles">
+      <segment state="initial">
+        <source>記事一覧</source>
+        <target>Article List</target>
+      </segment>
+    </unit>
+    <unit id="breadcrumb.home">
+      <segment state="initial">
+        <source>ホーム</source>
+        <target>Home</target>
+      </segment>
+    </unit>
+    <unit id="breadcrumb.nav.label">
+      <segment state="initial">
+        <source>パンくずリスト</source>
+        <target>Breadcrumb</target>
       </segment>
     </unit>
     <unit id="colorPaletteHelpOverview">

--- a/src/resources/texts/def/messages.xlf
+++ b/src/resources/texts/def/messages.xlf
@@ -456,6 +456,11 @@
         <source>SVGビューアーについて</source>
       </segment>
     </unit>
+    <unit id="page.dashboard.breadcrumb">
+      <segment>
+        <source>無料で使える開発者ツール集</source>
+      </segment>
+    </unit>
     <unit id="page.dashboard.card.ad.title">
       <segment>
         <source>広告</source>
@@ -1466,6 +1471,21 @@ OFFの場合はdecodeURIを使用し、URL構造を維持したままデコー�
     <unit id="cookieConsentBannerMessage">
       <segment>
         <source> 当サイトでは、サービスの向上および最適なパーソナライズのためにCookieを使用しています。詳細は<pc id="0" equivStart="START_LINK" equivEnd="CLOSE_LINK" type="link" dispStart="&lt;a routerLink=&quot;/privacy-policy&quot; (click)=&quot;onPrivacyPolicy()&quot;&gt;" dispEnd="&lt;/a&gt;">プライバシーポリシー</pc>をご確認ください。 </source>
+      </segment>
+    </unit>
+    <unit id="breadcrumb.articles">
+      <segment>
+        <source>記事一覧</source>
+      </segment>
+    </unit>
+    <unit id="breadcrumb.home">
+      <segment>
+        <source>ホーム</source>
+      </segment>
+    </unit>
+    <unit id="breadcrumb.nav.label">
+      <segment>
+        <source>パンくずリスト</source>
       </segment>
     </unit>
     <unit id="colorPaletteHelpOverview">


### PR DESCRIPTION
## 概要
全ページにh1が1つも存在しない問題（Google未インデックス調査、`docs/core/tech/incident-report-indexing.md`）に対応するため、単純にh1を追加するのではなく、全ページ共通のパンくずリストを導入し、その末尾（現在ページ）を`<h1>`としてマークアップします。

## 変更点
- `src/app/components/breadcrumb/`: 新規`BreadcrumbComponent`（`breadcrumb.model.ts`型定義含む）。`NavigationEnd`購読でleaf routeを解決し、末尾ノードを`<h1>`として描画。既存Material M3トークン（`--mat-sys-...`）のみ使用し、`app-header`/`app-sitemap`と同じ控えめな補助UIとして実装
- `src/app/core/services/breadcrumb.service.ts`: 新規`BreadcrumbService`。ダッシュボード／`MENU_CATEGORIES`一致ツールページ／`route.data.breadcrumb`ベースの3系統でトレイルを解決
- `src/app/core/services/structured-data.service.ts`: 既存`SoftwareApplication`用フィールドとは別に`setBreadcrumbList()`を追加し、BreadcrumbList JSON-LDを出力（URLを持たない中間ノードは除外、ホームURLの末尾スラッシュを正規化）
- `src/app/app.component.html` / `.ts`: `<app-breadcrumb>`を`app-sidenav`内・`router-outlet`直前に1箇所だけ配置し、全ページに自動波及
- `src/app/pages/{dashboard,guide,privacy-policy,operator-info,menu,articles}-page/*.routes.ts`: `data.breadcrumb`（`RouteBreadcrumb`）を追加。ダッシュボードには専用のh1向けラベルを新設
- i18n: `breadcrumb.home`/`breadcrumb.nav.label`/`breadcrumb.articles`/`page.dashboard.breadcrumb`を追加し、`messages.en.xlf`に直訳ではない独立した英語コピーを追加

## 動作確認
- [x] `yarn build`（ja/en両方ビルド成功）
- [x] `dist/ng-devtools/browser/{ja,en}/**/index.html`全ページで`<h1`が1個ずつのみ存在することをgrepで確認
- [x] `node scripts/verify-url-consistency.mjs` 成功
- [x] `node --test tests/url-consistency/*.mjs` 成功
- [x] `yarn test`（既存56テスト + 新規スペック含め全て成功）
- [x] `grep -n '<target/>' src/resources/texts/def/messages.en.xlf` が空
- [x] BreadcrumbList JSON-LDをビルド後HTMLから目視確認（下記参照）

closes #207