### PR TITLE
hreflang x-defaultを各ページ自身のURLに修正する

### DIFF
--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -185,7 +185,7 @@ for (const locale of LOCALES) {
       `  <link rel="canonical" href="${BASE_URL}${urlPath}">`,
       `  <link rel="alternate" hreflang="${locale}" href="${BASE_URL}${urlPath}">`,
       `  <link rel="alternate" hreflang="${altLocale}" href="${BASE_URL}${altUrlPath}">`,
-      `  <link rel="alternate" hreflang="x-default" href="${BASE_URL}/ja">`,
+      `  <link rel="alternate" hreflang="x-default" href="${BASE_URL}${urlPath}">`,
     ].join('\n');
 
     const injected = html.replace('</head>', `${tags}\n</head>`);


### PR DESCRIPTION
## 概要
`scripts/postbuild.mjs` の hreflang タグ注入処理で、`x-default` の href が常に `${BASE_URL}/ja`（トップページ）にハードコードされていた不具合を修正しました。各ツールの個別ページ（例: `/ja/api-key-generator`）でも `x-default` がトップページを指してしまい、検索エンジンに誤ったURLを伝えていました。

## 変更点
- `scripts/postbuild.mjs`: `x-default` タグの href を、canonical/hreflang(ja/en) と同様に各ページ自身の `urlPath` を使うよう修正（1行のみ）

## 動作確認
- [x] `yarn build` を実行し、生成された `dist/ng-devtools/browser/{ja,en}/**/index.html` を目視確認
- [x] `node scripts/verify-url-consistency.mjs` を実行し合格を確認
- [x] canonical・hreflang(ja/en)タグの出力に影響がないことを確認
- [x] UI/見た目には影響なし（ビルド成果物のhead内linkタグのみの修正）

### 確認した出力例

トップページ (`ja/index.html`):
```
<link rel="canonical" href="https://devtools.morihara.tech/ja">
<link rel="alternate" hreflang="ja" href="https://devtools.morihara.tech/ja">
<link rel="alternate" hreflang="en" href="https://devtools.morihara.tech/en">
<link rel="alternate" hreflang="x-default" href="https://devtools.morihara.tech/ja">
```

個別ページ (`ja/api-key-generator/index.html`):
```
<link rel="canonical" href="https://devtools.morihara.tech/ja/api-key-generator">
<link rel="alternate" hreflang="ja" href="https://devtools.morihara.tech/ja/api-key-generator">
<link rel="alternate" hreflang="en" href="https://devtools.morihara.tech/en/api-key-generator">
<link rel="alternate" hreflang="x-default" href="https://devtools.morihara.tech/ja/api-key-generator">
```

個別ページ (`en/api-key-generator/index.html`):
```
<link rel="canonical" href="https://devtools.morihara.tech/en/api-key-generator">
<link rel="alternate" hreflang="en" href="https://devtools.morihara.tech/en/api-key-generator">
<link rel="alternate" hreflang="ja" href="https://devtools.morihara.tech/ja/api-key-generator">
<link rel="alternate" hreflang="x-default" href="https://devtools.morihara.tech/en/api-key-generator">
```

修正前は個別ページの `x-default` も `https://devtools.morihara.tech/ja` のままだったが、修正後は各ページ自身のURLになっていることを確認済み。

`node scripts/verify-url-consistency.mjs` 実行結果:
```
URL consistency check passed: no canonical/hreflang/internal-link/sitemap URL would be redirected.
```

closes #213